### PR TITLE
Expand core primitives with charts, tables, gauges, and clipping polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,3 +79,4 @@ Dashboard-style UI:
 Mixed font text model showcase:
 
 ![Mixed font showcase screenshot](docs/screenshots/fonts.png)
+

--- a/examples/core_primitives_parity_showcase.rs
+++ b/examples/core_primitives_parity_showcase.rs
@@ -1,0 +1,120 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 240;
+const H: u32 = 140;
+static CHART_SERIES: [f32; 8] = [0.1, 0.4, 0.2, 0.7, 0.5, 0.8, 0.3, 0.6];
+static TABLE_ROWS: [&[&str]; 3] = [&["CPU", "64"], &["MEM", "73"], &["NET", "41"]];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("core primitives parity showcase", &settings);
+    let mut gui = GuiContext::<24, 24, 24>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+    let mut bars_mode = false;
+    let mut clip_children = true;
+    let mut gauge_value = 0.4f32;
+
+    'running: loop {
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Num1 => {
+                        bars_mode = !bars_mode;
+                        let mode = if bars_mode {
+                            ChartMode::Bars
+                        } else {
+                            ChartMode::Line
+                        };
+                        gui.set_chart_decoration(ids.chart, mode, true, true, true)
+                            .unwrap();
+                    }
+                    Keycode::Num2 => {
+                        clip_children = !clip_children;
+                        gui.set_flag(ids.clip_panel, WidgetFlags::CLIP_CHILDREN, clip_children)
+                            .unwrap();
+                    }
+                    Keycode::Num3 => {
+                        gauge_value = (gauge_value + 0.1).fract();
+                        gui.set_gauge_value(ids.gauge, gauge_value).unwrap();
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    chart: WidgetId,
+    gauge: WidgetId,
+    clip_panel: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 24, 24, 24>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 228, 128), Style::panel()).unwrap();
+    gui.add_label(
+        Rect::new(10, 10, 220, 10),
+        "[1] chart mode [2] clip toggle [3] gauge value",
+        Style::label(),
+    )
+    .unwrap();
+
+    let chart = gui
+        .add_chart(Rect::new(12, 24, 104, 46), &CHART_SERIES, 0.0, 1.0, Style::panel())
+        .unwrap();
+    gui.set_chart_style(chart, 2, true, true).unwrap();
+    gui.set_chart_decoration(chart, ChartMode::Line, true, true, true)
+        .unwrap();
+
+    let gauge = gui
+        .add_arc_gauge(
+            Rect::new(124, 24, 48, 48),
+            0.4,
+            0.0,
+            1.0,
+            135,
+            405,
+            2,
+            true,
+            Style::progress(),
+        )
+        .unwrap();
+    gui.set_gauge_ticks(gauge, 6, 2, true).unwrap();
+
+    let table = gui
+        .add_table(Rect::new(176, 24, 52, 46), &TABLE_ROWS, Style::panel())
+        .unwrap();
+    gui.set_table_style(table, true, 1, TextAlign::Center).unwrap();
+
+    let clip_panel = gui
+        .add_panel(Rect::new(12, 78, 90, 42), Style::panel())
+        .unwrap();
+    let overflowing = gui
+        .add_label(Rect::new(68, 14, 80, 10), "CLIP DEMO", Style::label())
+        .unwrap();
+    gui.add_child(clip_panel, overflowing).unwrap();
+
+    Ids {
+        chart,
+        gauge,
+        clip_panel,
+    }
+}

--- a/examples/event_dispatch_showcase.rs
+++ b/examples/event_dispatch_showcase.rs
@@ -1,0 +1,142 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 220;
+const H: u32 = 132;
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("event dispatch showcase", &settings);
+
+    let mut gui = GuiContext::<16, 48, 16>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+    gui.set_dispatch_policy(
+        ids.guard,
+        WidgetDispatchPolicy::stop(WidgetEventFilter::POINTER, EventPhaseMask::CAPTURE),
+    )
+    .unwrap();
+
+    let mut stop_capture = true;
+    let mut frame_count = 0i32;
+    let mut click_count = 0i32;
+
+    'running: loop {
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Space => {
+                        // Trigger a pointer-style activation against the target button.
+                        gui.handle_input(InputEvent::Pointer {
+                            x: 26,
+                            y: 66,
+                            state: PointerState::Pressed,
+                            button: PointerButton::Primary,
+                        })
+                        .unwrap();
+                    }
+                    Keycode::Return => {
+                        stop_capture = !stop_capture;
+                        if stop_capture {
+                            gui.set_dispatch_policy(
+                                ids.guard,
+                                WidgetDispatchPolicy::stop(
+                                    WidgetEventFilter::POINTER,
+                                    EventPhaseMask::CAPTURE,
+                                ),
+                            )
+                            .unwrap();
+                            gui.set_value_label(ids.mode, 1).unwrap();
+                        } else {
+                            gui.clear_dispatch_policy(ids.guard).unwrap();
+                            gui.set_value_label(ids.mode, 0).unwrap();
+                        }
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        frame_count = (frame_count + 1) % 1000;
+        gui.set_value_label(ids.frames, frame_count).unwrap();
+
+        while let Some(event) = gui.pop_event() {
+            match event {
+                UiEvent::PointerPressed(id) if id == ids.button => {
+                    gui.set_value_label(ids.pointer_hit, 1).unwrap();
+                }
+                UiEvent::Clicked(id) if id == ids.button => {
+                    click_count += 1;
+                    gui.set_value_label(ids.clicks, click_count).unwrap();
+                }
+                _ => {}
+            }
+        }
+
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    guard: WidgetId,
+    button: WidgetId,
+    mode: WidgetId,
+    pointer_hit: WidgetId,
+    clicks: WidgetId,
+    frames: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 16, 48, 16>) -> Ids {
+    let root = gui
+        .add_panel(Rect::new(6, 6, 208, 120), Style::panel())
+        .unwrap();
+    let guard = gui
+        .add_panel(Rect::new(14, 34, 192, 84), Style::panel())
+        .unwrap();
+    gui.add_child(root, guard).unwrap();
+
+    gui.add_label(
+        Rect::new(12, 12, 196, 20),
+        "SPACE=POINTER PRESS\nENTER=TOGGLE CAPTURE STOP",
+        Style::label(),
+    )
+    .unwrap();
+    let mode = gui
+        .add_value_label(Rect::new(14, 36, 64, 12), "STOP", 1, Style::panel())
+        .unwrap();
+    let pointer_hit = gui
+        .add_value_label(Rect::new(82, 36, 64, 12), "HIT", 0, Style::panel())
+        .unwrap();
+    let clicks = gui
+        .add_value_label(Rect::new(150, 36, 56, 12), "CLICK", 0, Style::panel())
+        .unwrap();
+    let frames = gui
+        .add_value_label(Rect::new(150, 104, 56, 12), "FRAME", 0, Style::panel())
+        .unwrap();
+    let button = gui
+        .add_button(Rect::new(20, 56, 104, 18), "TARGET BUTTON", Style::button())
+        .unwrap();
+    gui.add_child(guard, button).unwrap();
+
+    Ids {
+        guard,
+        button,
+        mode,
+        pointer_hit,
+        clicks,
+        frames,
+    }
+}

--- a/examples/long_press_input_showcase.rs
+++ b/examples/long_press_input_showcase.rs
@@ -1,0 +1,124 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 200;
+const H: u32 = 120;
+const PRESS_X: i32 = 20;
+const PRESS_Y: i32 = 42;
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("long press input showcase", &settings);
+
+    let mut gui = GuiContext::<12, 24, 12>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+    gui.set_long_press_threshold_ms(600);
+
+    let mut pointer_held = false;
+    let mut clicks = 0i32;
+    let mut long_presses = 0i32;
+
+    'running: loop {
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Space => {
+                        if !pointer_held {
+                            gui.handle_input(InputEvent::Pointer {
+                                x: PRESS_X,
+                                y: PRESS_Y,
+                                state: PointerState::Pressed,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                            pointer_held = true;
+                            gui.set_value_label(ids.state, 1).unwrap();
+                        }
+                    }
+                    Keycode::Return => {
+                        gui.handle_input(InputEvent::Pointer {
+                            x: PRESS_X,
+                            y: PRESS_Y,
+                            state: PointerState::Released,
+                            button: PointerButton::Primary,
+                        })
+                        .unwrap();
+                        pointer_held = false;
+                        gui.set_value_label(ids.state, 0).unwrap();
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        gui.tick_input(16).unwrap();
+        while let Some(event) = gui.pop_event() {
+            match event {
+                UiEvent::LongPressed(id) if id == ids.button => {
+                    long_presses += 1;
+                    gui.set_value_label(ids.long_count, long_presses).unwrap();
+                }
+                UiEvent::Clicked(id) if id == ids.button => {
+                    clicks += 1;
+                    gui.set_value_label(ids.click_count, clicks).unwrap();
+                }
+                UiEvent::PointerReleased(id) if id == ids.button => {
+                    gui.set_value_label(ids.state, 0).unwrap();
+                }
+                _ => {}
+            }
+        }
+
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    button: WidgetId,
+    click_count: WidgetId,
+    long_count: WidgetId,
+    state: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 12, 24, 12>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 188, 108), Style::panel())
+        .unwrap();
+    gui.add_label(
+        Rect::new(12, 12, 176, 20),
+        "SPACE=PRESS/HOLD\nENTER=RELEASE",
+        Style::label(),
+    )
+    .unwrap();
+    let button = gui
+        .add_button(Rect::new(20, 36, 96, 16), "PRESS TARGET", Style::button())
+        .unwrap();
+    let click_count = gui
+        .add_value_label(Rect::new(20, 60, 80, 12), "CLICK", 0, Style::panel())
+        .unwrap();
+    let long_count = gui
+        .add_value_label(Rect::new(108, 60, 80, 12), "LONG", 0, Style::panel())
+        .unwrap();
+    let state = gui
+        .add_value_label(Rect::new(20, 78, 168, 12), "IDLE", 0, Style::panel())
+        .unwrap();
+    Ids {
+        button,
+        click_count,
+        long_count,
+        state,
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,13 +10,13 @@ use crate::{
     },
     layout::{Axis, LayoutItem, LinearLayout},
     present::PresentRegion,
-    render::{RenderCtx, RenderQuality},
+    render::{RenderCtx, RenderQuality, TextAlign},
     state::{ListState, ScrollState, SliderState, TabsState},
     style::{Style, Theme, VisualState, WidgetStyle, lerp_style},
     widget::{
         EventContext, EventPhase, EventPolicy, FocusGroupId, StyleClassId, WidgetFlags, WidgetId,
     },
-    widgets::{KeyboardLayout, WidgetKind, WidgetNode},
+    widgets::{ChartMode, KeyboardLayout, WidgetKind, WidgetNode},
 };
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -33,6 +33,13 @@ impl From<DirtyError> for GuiError {
     }
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct PressTracker {
+    id: WidgetId,
+    elapsed_ms: u32,
+    long_emitted: bool,
+}
+
 pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize> {
     viewport: Rect,
     widgets: Vec<WidgetNode<'a>, NODES>,
@@ -45,6 +52,8 @@ pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: 
     focus: Option<WidgetId>,
     active_focus_group: Option<FocusGroupId>,
     render_quality: RenderQuality,
+    long_press_ms: u32,
+    pressed: Option<PressTracker>,
     next_id: u16,
 }
 
@@ -66,6 +75,8 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             focus: None,
             active_focus_group: None,
             render_quality: RenderQuality::High,
+            long_press_ms: 500,
+            pressed: None,
             next_id: 1,
         }
     }
@@ -86,8 +97,17 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.dispatch_policies.clear();
         self.class_styles.clear();
         self.focus = None;
+        self.pressed = None;
         self.dirty.mark_all(self.viewport)?;
         Ok(())
+    }
+
+    pub const fn long_press_threshold_ms(&self) -> u32 {
+        self.long_press_ms
+    }
+
+    pub fn set_long_press_threshold_ms(&mut self, threshold_ms: u32) {
+        self.long_press_ms = threshold_ms.max(1);
     }
 
     pub fn widgets(&self) -> &[WidgetNode<'a>] {
@@ -611,6 +631,9 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 end_deg,
                 thickness: thickness.max(1),
                 antialias,
+                major_ticks: 6,
+                minor_ticks: 2,
+                show_value: false,
             },
             style,
         )
@@ -627,7 +650,18 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     where
         S: Into<WidgetStyle>,
     {
-        self.add_widget(rect, WidgetKind::Gauge { value, min, max }, style)
+        self.add_widget(
+            rect,
+            WidgetKind::Gauge {
+                value,
+                min,
+                max,
+                major_ticks: 6,
+                minor_ticks: 2,
+                show_value: false,
+            },
+            style,
+        )
     }
 
     pub fn add_gauge_needle<S>(
@@ -676,6 +710,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 thickness: 1,
                 fill_under: false,
                 markers: false,
+                mode: ChartMode::Line,
+                show_grid: false,
+                show_axes: false,
+                show_labels: false,
             },
             style,
         )
@@ -700,6 +738,35 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 *t = thickness.max(1);
                 *fill = fill_under;
                 *mark = markers;
+                self.dirty.add(rect)?;
+                Ok(())
+            }
+            _ => Err(GuiError::NotFound),
+        }
+    }
+
+    pub fn set_chart_decoration(
+        &mut self,
+        id: WidgetId,
+        mode: ChartMode,
+        show_grid: bool,
+        show_axes: bool,
+        show_labels: bool,
+    ) -> Result<(), GuiError> {
+        let rect = self.absolute_rect(id).ok_or(GuiError::NotFound)?;
+        let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
+        match node.kind {
+            WidgetKind::Chart {
+                mode: ref mut chart_mode,
+                show_grid: ref mut grid,
+                show_axes: ref mut axes,
+                show_labels: ref mut labels,
+                ..
+            } => {
+                *chart_mode = mode;
+                *grid = show_grid;
+                *axes = show_axes;
+                *labels = show_labels;
                 self.dirty.add(rect)?;
                 Ok(())
             }
@@ -760,7 +827,42 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     where
         S: Into<WidgetStyle>,
     {
-        self.add_widget(rect, WidgetKind::Table { rows }, style)
+        self.add_widget(
+            rect,
+            WidgetKind::Table {
+                rows,
+                separators: true,
+                cell_padding: 1,
+                align: TextAlign::Left,
+            },
+            style,
+        )
+    }
+
+    pub fn set_table_style(
+        &mut self,
+        id: WidgetId,
+        separators: bool,
+        cell_padding: u8,
+        align: TextAlign,
+    ) -> Result<(), GuiError> {
+        let rect = self.absolute_rect(id).ok_or(GuiError::NotFound)?;
+        let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
+        match node.kind {
+            WidgetKind::Table {
+                separators: ref mut cell_sep,
+                cell_padding: ref mut pad,
+                align: ref mut table_align,
+                ..
+            } => {
+                *cell_sep = separators;
+                *pad = cell_padding.min(6);
+                *table_align = align;
+                self.dirty.add(rect)?;
+                Ok(())
+            }
+            _ => Err(GuiError::NotFound),
+        }
     }
 
     pub fn add_textarea<S>(
@@ -1017,7 +1119,6 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     }
 
     pub fn set_scroll_offset(&mut self, id: WidgetId, offset_y: i32) -> Result<(), GuiError> {
-        let rect = self.absolute_rect(id).ok_or(GuiError::NotFound)?;
         let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
         match node.kind {
             WidgetKind::ScrollView {
@@ -1027,7 +1128,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 let mut state = ScrollState::new(*v, content_h);
                 state.set_offset(offset_y);
                 *v = state.offset_y;
-                self.dirty.add(rect)?;
+                self.mark_subtree_dirty(id)?;
                 Ok(())
             }
             _ => Err(GuiError::NotFound),
@@ -1289,6 +1390,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 value: ref mut v,
                 min,
                 max,
+                ..
             }
             | WidgetKind::ArcGauge {
                 value: ref mut v,
@@ -1303,6 +1405,38 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 ..
             } => {
                 *v = value.clamp(min.min(max), min.max(max));
+                self.dirty.add(rect)?;
+                Ok(())
+            }
+            _ => Err(GuiError::NotFound),
+        }
+    }
+
+    pub fn set_gauge_ticks(
+        &mut self,
+        id: WidgetId,
+        major_ticks: u8,
+        minor_ticks: u8,
+        show_value: bool,
+    ) -> Result<(), GuiError> {
+        let rect = self.absolute_rect(id).ok_or(GuiError::NotFound)?;
+        let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
+        match node.kind {
+            WidgetKind::Gauge {
+                major_ticks: ref mut major,
+                minor_ticks: ref mut minor,
+                show_value: ref mut show,
+                ..
+            }
+            | WidgetKind::ArcGauge {
+                major_ticks: ref mut major,
+                minor_ticks: ref mut minor,
+                show_value: ref mut show,
+                ..
+            } => {
+                *major = major_ticks.max(1);
+                *minor = minor_ticks.max(1);
+                *show = show_value;
                 self.dirty.add(rect)?;
                 Ok(())
             }
@@ -1798,6 +1932,30 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         }
     }
 
+    pub fn tick_input(&mut self, dt_ms: u32) -> Result<(), GuiError> {
+        let Some(mut pressed) = self.pressed else {
+            return Ok(());
+        };
+        if pressed.long_emitted {
+            return Ok(());
+        }
+        if !self.effective_visible(pressed.id) || !self.effective_enabled(pressed.id) {
+            self.pressed = None;
+            return Ok(());
+        }
+        pressed.elapsed_ms = pressed.elapsed_ms.saturating_add(dt_ms);
+        if pressed.elapsed_ms >= self.long_press_ms {
+            let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+            self.dispatch_widget_event(pressed.id, WidgetEventKind::LongPressed, &mut events, |_| {
+                EventPolicy::Continue
+            })?;
+            self.push_event(UiEvent::LongPressed(pressed.id))?;
+            pressed.long_emitted = true;
+        }
+        self.pressed = Some(pressed);
+        Ok(())
+    }
+
     pub fn pop_event(&mut self) -> Option<UiEvent> {
         if self.events.is_empty() {
             None
@@ -2096,7 +2254,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             current = self.node(widget_id)?.parent;
         }
         for widget_id in chain.iter().rev().copied() {
-            clip = clip.intersection(self.absolute_rect(widget_id)?);
+            let node = self.node(widget_id)?;
+            if widget_id == id || node.clips_children() {
+                clip = clip.intersection(self.absolute_rect(widget_id)?);
+            }
             if clip.is_empty() {
                 return None;
             }
@@ -2404,11 +2565,17 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
 
         if let Some(id) = hit {
             self.dispatch_activation(id, true)?;
+            self.pressed = Some(PressTracker {
+                id,
+                elapsed_ms: 0,
+                long_emitted: false,
+            });
         }
         Ok(())
     }
 
     fn handle_pointer_released(&mut self, x: i32, y: i32) -> Result<(), GuiError> {
+        self.pressed = None;
         let hit = self
             .widgets
             .iter()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ pub use widget_animation::{
     AnimatedProperty, AnimationConflictPolicy, BindingSnapshot, WidgetAnimationCallbacks,
     WidgetAnimationError, WidgetAnimator,
 };
-pub use widgets::{KeyboardLayout, WidgetKind, WidgetNode};
+pub use widgets::{ChartMode, KeyboardLayout, WidgetKind, WidgetNode};
 
 pub mod prelude {
     pub use crate::{
@@ -106,6 +106,7 @@ pub mod prelude {
         VisualState, WidgetAnimationCallbacks, WidgetAnimationError, WidgetAnimator,
         AnimationConflictPolicy, BindingSnapshot, WidgetDispatchPolicy, WidgetEvent,
         WidgetEventFilter, WidgetEventKind, WidgetFlags, WidgetId, WidgetKind, WidgetStyle, KeyboardLayout,
+        ChartMode,
         TextShaper, BasicTextShaper, ShapingConfig, ShapedGlyph, TextDirection,
         apply_easing,
     };

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -1,4 +1,7 @@
+use core::fmt::Write;
+
 use embedded_graphics_core::pixelcolor::{Rgb565, RgbColor};
+use heapless::String;
 
 use crate::{
     block::Block,
@@ -73,11 +76,17 @@ pub enum WidgetKind<'a> {
         end_deg: i32,
         thickness: u8,
         antialias: bool,
+        major_ticks: u8,
+        minor_ticks: u8,
+        show_value: bool,
     },
     Gauge {
         value: f32,
         min: f32,
         max: f32,
+        major_ticks: u8,
+        minor_ticks: u8,
+        show_value: bool,
     },
     GaugeNeedle {
         value: f32,
@@ -93,6 +102,10 @@ pub enum WidgetKind<'a> {
         thickness: u8,
         fill_under: bool,
         markers: bool,
+        mode: ChartMode,
+        show_grid: bool,
+        show_axes: bool,
+        show_labels: bool,
     },
     Spinner {
         phase: f32,
@@ -107,6 +120,9 @@ pub enum WidgetKind<'a> {
     },
     Table {
         rows: &'a [&'a [&'a str]],
+        separators: bool,
+        cell_padding: u8,
+        align: TextAlign,
     },
     TextArea {
         text: &'a str,
@@ -131,6 +147,12 @@ pub enum WidgetKind<'a> {
         items: &'a [&'a str],
         selected: usize,
     },
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ChartMode {
+    Line,
+    Bars,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -295,11 +317,45 @@ impl<'a> WidgetNode<'a> {
                 end_deg,
                 thickness,
                 antialias,
+                major_ticks,
+                minor_ticks,
+                show_value,
             } => render_arc_gauge(
-                ctx, rect, value, min, max, start_deg, end_deg, thickness, antialias, self.style, state,
+                ctx,
+                rect,
+                value,
+                min,
+                max,
+                start_deg,
+                end_deg,
+                thickness,
+                antialias,
+                major_ticks,
+                minor_ticks,
+                show_value,
+                self.style,
+                state,
             ),
-            WidgetKind::Gauge { value, min, max } => {
-                render_gauge(ctx, rect, value, min, max, self.style, state)
+            WidgetKind::Gauge {
+                value,
+                min,
+                max,
+                major_ticks,
+                minor_ticks,
+                show_value,
+            } => {
+                render_gauge(
+                    ctx,
+                    rect,
+                    value,
+                    min,
+                    max,
+                    major_ticks,
+                    minor_ticks,
+                    show_value,
+                    self.style,
+                    state,
+                )
             }
             WidgetKind::GaugeNeedle {
                 value,
@@ -315,9 +371,26 @@ impl<'a> WidgetNode<'a> {
                 thickness,
                 fill_under,
                 markers,
+                mode,
+                show_grid,
+                show_axes,
+                show_labels,
             } => {
                 render_chart(
-                    ctx, rect, values, min, max, thickness, fill_under, markers, self.style, state,
+                    ctx,
+                    rect,
+                    values,
+                    min,
+                    max,
+                    thickness,
+                    fill_under,
+                    markers,
+                    mode,
+                    show_grid,
+                    show_axes,
+                    show_labels,
+                    self.style,
+                    state,
                 )
             }
             WidgetKind::Spinner { phase } => render_spinner(ctx, rect, phase, self.style, state),
@@ -327,7 +400,21 @@ impl<'a> WidgetNode<'a> {
             WidgetKind::Roller { items, selected } => {
                 render_roller(ctx, rect, items, selected, self.style, state)
             }
-            WidgetKind::Table { rows } => render_table(ctx, rect, rows, self.style, state),
+            WidgetKind::Table {
+                rows,
+                separators,
+                cell_padding,
+                align,
+            } => render_table(
+                ctx,
+                rect,
+                rows,
+                separators,
+                cell_padding,
+                align,
+                self.style,
+                state,
+            ),
             WidgetKind::TextArea {
                 text,
                 cursor,
@@ -877,6 +964,9 @@ fn render_arc_gauge<D>(
     end_deg: i32,
     thickness: u8,
     antialias: bool,
+    major_ticks: u8,
+    minor_ticks: u8,
+    show_value: bool,
     style: WidgetStyle,
     state: VisualState,
 ) -> Result<(), D::Error>
@@ -890,13 +980,25 @@ where
     let cx = inner.x + inner.w as i32 / 2;
     let cy = inner.y + inner.h as i32 / 2;
     let radius = (inner.w.min(inner.h) / 2).saturating_sub(1);
+    let track = Rgb565::new(5, 8, 8);
+    draw_arc_ticks(
+        ctx,
+        cx,
+        cy,
+        radius.saturating_sub((thickness.max(1) / 2) as u32),
+        start_deg,
+        end_deg,
+        major_ticks,
+        minor_ticks,
+        track,
+    )?;
     ctx.stroke_arc_styled(
         cx,
         cy,
         radius,
         start_deg,
         end_deg,
-        StrokeStyle::new(Rgb565::new(5, 8, 8))
+        StrokeStyle::new(track)
             .with_width(thickness)
             .with_antialias(antialias),
     )?;
@@ -912,7 +1014,11 @@ where
         StrokeStyle::new(style.accent)
             .with_width(thickness)
             .with_antialias(antialias),
-    )
+    )?;
+    if show_value {
+        draw_gauge_value_label(ctx, inner, value, min, max, style)?;
+    }
+    Ok(())
 }
 
 fn render_gauge<D>(
@@ -921,13 +1027,31 @@ fn render_gauge<D>(
     value: f32,
     min: f32,
     max: f32,
+    major_ticks: u8,
+    minor_ticks: u8,
+    show_value: bool,
     style: WidgetStyle,
     state: VisualState,
 ) -> Result<(), D::Error>
 where
     D: embedded_graphics_core::draw_target::DrawTarget<Color = Rgb565>,
 {
-    render_arc_gauge(ctx, rect, value, min, max, 135, 405, 2, true, style, state)
+    render_arc_gauge(
+        ctx,
+        rect,
+        value,
+        min,
+        max,
+        135,
+        405,
+        2,
+        true,
+        major_ticks,
+        minor_ticks,
+        show_value,
+        style,
+        state,
+    )
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -987,6 +1111,10 @@ fn render_chart<D>(
     thickness: u8,
     fill_under: bool,
     markers: bool,
+    mode: ChartMode,
+    show_grid: bool,
+    show_axes: bool,
+    show_labels: bool,
     style: WidgetStyle,
     state: VisualState,
 ) -> Result<(), D::Error>
@@ -1000,39 +1128,113 @@ where
         return Ok(());
     }
     let inner = block.inner(rect);
-    let range = (max - min).max(f32::EPSILON);
-    let dx = (inner.w.saturating_sub(1) as f32) / (values.len().saturating_sub(1) as f32);
-    for i in 1..values.len() {
-        let v0 = ((values[i - 1] - min) / range).clamp(0.0, 1.0);
-        let v1 = ((values[i] - min) / range).clamp(0.0, 1.0);
-        let x0 = inner.x + ((i - 1) as f32 * dx) as i32;
-        let x1 = inner.x + (i as f32 * dx) as i32;
-        let y0 = inner.bottom() - 1 - (v0 * (inner.h.saturating_sub(1)) as f32) as i32;
-        let y1 = inner.bottom() - 1 - (v1 * (inner.h.saturating_sub(1)) as f32) as i32;
-        if fill_under {
-            let base = inner.bottom() - 1;
-            ctx.fill_polygon(
-                &[
-                    embedded_graphics_core::geometry::Point::new(x0, base),
-                    embedded_graphics_core::geometry::Point::new(x0, y0),
-                    embedded_graphics_core::geometry::Point::new(x1, y1),
-                    embedded_graphics_core::geometry::Point::new(x1, base),
-                ],
-                Rgb565::new(2, 8, 2),
+    if show_grid {
+        for row in [1u32, 2, 3] {
+            let y = inner.y + ((inner.h.saturating_sub(1) * row) / 4) as i32;
+            ctx.draw_line_styled(
+                inner.x,
+                y,
+                inner.right().saturating_sub(1),
+                y,
+                StrokeStyle::new(Rgb565::new(6, 10, 10)).with_width(1),
             )?;
         }
+    }
+    if show_axes {
+        let axis = Rgb565::new(12, 18, 18);
         ctx.draw_line_styled(
-            x0,
-            y0,
-            x1,
-            y1,
-            StrokeStyle::new(style.accent)
-                .with_width(thickness.max(1))
-                .with_antialias(true),
+            inner.x,
+            inner.y,
+            inner.x,
+            inner.bottom().saturating_sub(1),
+            StrokeStyle::new(axis).with_width(1),
         )?;
-        if markers {
-            ctx.fill_circle(x0, y0, 1, style.accent)?;
-            ctx.fill_circle(x1, y1, 1, style.accent)?;
+        ctx.draw_line_styled(
+            inner.x,
+            inner.bottom().saturating_sub(1),
+            inner.right().saturating_sub(1),
+            inner.bottom().saturating_sub(1),
+            StrokeStyle::new(axis).with_width(1),
+        )?;
+    }
+    if show_labels {
+        let mut max_label: String<12> = String::new();
+        let _ = write!(&mut max_label, "{:.1}", max);
+        let mut min_label: String<12> = String::new();
+        let _ = write!(&mut min_label, "{:.1}", min);
+        ctx.draw_text_in(
+            Rect::new(inner.x + 1, inner.y, inner.w.saturating_sub(2), style.font.line_height()),
+            max_label.as_str(),
+            TextStyle::new(style.text).with_font(style.font),
+        )?;
+        ctx.draw_text_in(
+            Rect::new(
+                inner.x + 1,
+                inner.bottom().saturating_sub(style.font.line_height() as i32),
+                inner.w.saturating_sub(2),
+                style.font.line_height(),
+            ),
+            min_label.as_str(),
+            TextStyle::new(style.text).with_font(style.font),
+        )?;
+    }
+    let range = (max - min).max(f32::EPSILON);
+    match mode {
+        ChartMode::Line => {
+            let dx = (inner.w.saturating_sub(1) as f32) / (values.len().saturating_sub(1) as f32);
+            for i in 1..values.len() {
+                let v0 = ((values[i - 1] - min) / range).clamp(0.0, 1.0);
+                let v1 = ((values[i] - min) / range).clamp(0.0, 1.0);
+                let x0 = inner.x + ((i - 1) as f32 * dx) as i32;
+                let x1 = inner.x + (i as f32 * dx) as i32;
+                let y0 = inner.bottom() - 1 - (v0 * (inner.h.saturating_sub(1)) as f32) as i32;
+                let y1 = inner.bottom() - 1 - (v1 * (inner.h.saturating_sub(1)) as f32) as i32;
+                if fill_under {
+                    let base = inner.bottom() - 1;
+                    ctx.fill_polygon(
+                        &[
+                            embedded_graphics_core::geometry::Point::new(x0, base),
+                            embedded_graphics_core::geometry::Point::new(x0, y0),
+                            embedded_graphics_core::geometry::Point::new(x1, y1),
+                            embedded_graphics_core::geometry::Point::new(x1, base),
+                        ],
+                        Rgb565::new(2, 8, 2),
+                    )?;
+                }
+                ctx.draw_line_styled(
+                    x0,
+                    y0,
+                    x1,
+                    y1,
+                    StrokeStyle::new(style.accent)
+                        .with_width(thickness.max(1))
+                        .with_antialias(true),
+                )?;
+                if markers {
+                    ctx.fill_circle(x0, y0, 1, style.accent)?;
+                    ctx.fill_circle(x1, y1, 1, style.accent)?;
+                }
+            }
+        }
+        ChartMode::Bars => {
+            let count = values.len() as u32;
+            let gap = 1u32;
+            let bar_w = inner
+                .w
+                .saturating_sub(gap.saturating_mul(count.saturating_sub(1)))
+                .max(count)
+                / count;
+            for (i, value) in values.iter().copied().enumerate() {
+                let t = ((value - min) / range).clamp(0.0, 1.0);
+                let h = (t * inner.h.saturating_sub(1) as f32) as u32;
+                let x = inner.x + (i as u32 * (bar_w + gap)) as i32;
+                let y = inner.bottom().saturating_sub(h as i32 + 1);
+                let bar = Rect::new(x, y, bar_w.max(1), h.max(1));
+                ctx.fill_rect(bar, style.accent)?;
+                if markers {
+                    ctx.fill_circle(x + (bar_w / 2) as i32, y, 1, style.text)?;
+                }
+            }
         }
     }
     Ok(())
@@ -1135,6 +1337,9 @@ fn render_table<D>(
     ctx: &mut RenderCtx<'_, D>,
     rect: Rect,
     rows: &[&[&str]],
+    separators: bool,
+    cell_padding: u8,
+    align: TextAlign,
     style: WidgetStyle,
     state: VisualState,
 ) -> Result<(), D::Error>
@@ -1149,25 +1354,101 @@ where
     }
     let inner = block.inner(rect);
     let row_h = (inner.h / rows.len() as u32).max(1);
+    let max_cols = rows.iter().map(|row| row.len()).max().unwrap_or(1).max(1);
+    let col_w = (inner.w / max_cols as u32).max(1);
     for (r, cols) in rows.iter().enumerate() {
-        let col_count = cols.len().max(1);
-        let col_w = (inner.w / col_count as u32).max(1);
-        for (c, text) in cols.iter().enumerate() {
+        for c in 0..max_cols {
+            let text = cols.get(c).copied().unwrap_or("");
             let cell = Rect::new(
                 inner.x + (c as u32 * col_w) as i32,
                 inner.y + (r as u32 * row_h) as i32,
                 col_w,
                 row_h,
             );
-            ctx.stroke_rect(cell, Border::one(style.border.color))?;
+            if separators {
+                ctx.stroke_rect(cell, Border::one(style.border.color))?;
+            }
             ctx.draw_text_in(
-                cell.inset(EdgeInsets::all(1)),
+                cell.inset(EdgeInsets::all(cell_padding as i16)),
                 text,
-                TextStyle::new(style.text).with_font(style.font),
+                TextStyle::new(style.text)
+                    .with_font(style.font)
+                    .with_align(align),
             )?;
         }
     }
     Ok(())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn draw_arc_ticks<D>(
+    ctx: &mut RenderCtx<'_, D>,
+    cx: i32,
+    cy: i32,
+    radius: u32,
+    start_deg: i32,
+    end_deg: i32,
+    major_ticks: u8,
+    minor_ticks: u8,
+    color: Rgb565,
+) -> Result<(), D::Error>
+where
+    D: embedded_graphics_core::draw_target::DrawTarget<Color = Rgb565>,
+{
+    let major_ticks = major_ticks.max(1);
+    let minor_ticks = minor_ticks.max(1);
+    let total_steps = (major_ticks as u32).saturating_mul(minor_ticks as u32);
+    for step in 0..=total_steps {
+        let t = if total_steps == 0 {
+            0.0
+        } else {
+            step as f32 / total_steps as f32
+        };
+        let angle = (start_deg as f32 + (end_deg - start_deg) as f32 * t).to_radians();
+        let is_major = step % minor_ticks as u32 == 0;
+        let tick_len = if is_major { 4 } else { 2 };
+        let outer_x = cx + (radius as f32 * angle.cos()) as i32;
+        let outer_y = cy + (radius as f32 * angle.sin()) as i32;
+        let inner_x = cx + ((radius.saturating_sub(tick_len)) as f32 * angle.cos()) as i32;
+        let inner_y = cy + ((radius.saturating_sub(tick_len)) as f32 * angle.sin()) as i32;
+        ctx.draw_line_styled(
+            inner_x,
+            inner_y,
+            outer_x,
+            outer_y,
+            StrokeStyle::new(color).with_width(1),
+        )?;
+    }
+    Ok(())
+}
+
+fn draw_gauge_value_label<D>(
+    ctx: &mut RenderCtx<'_, D>,
+    inner: Rect,
+    value: f32,
+    min: f32,
+    max: f32,
+    style: Style,
+) -> Result<(), D::Error>
+where
+    D: embedded_graphics_core::draw_target::DrawTarget<Color = Rgb565>,
+{
+    let range = (max - min).max(f32::EPSILON);
+    let percent = (((value - min) / range).clamp(0.0, 1.0) * 100.0).round() as i32;
+    let mut label: String<8> = String::new();
+    let _ = write!(&mut label, "{}%", percent);
+    ctx.draw_text_in(
+        Rect::new(
+            inner.x,
+            inner.y + (inner.h as i32 / 2) - (style.font.line_height() as i32 / 2),
+            inner.w,
+            style.font.line_height(),
+        ),
+        label.as_str(),
+        TextStyle::new(style.text)
+            .with_font(style.font)
+            .with_align(TextAlign::Center),
+    )
 }
 
 fn render_textarea<D>(

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -1486,6 +1486,8 @@ fn new_widgets_chart_spinner_dropdown_render_and_update() {
         .add_chart(Rect::new(0, 0, 32, 16), &SERIES, 0.0, 1.0, Style::panel())
         .unwrap();
     gui.set_chart_style(chart, 2, true, true).unwrap();
+    gui.set_chart_decoration(chart, ChartMode::Bars, true, true, true)
+        .unwrap();
     let spinner = gui
         .add_spinner(Rect::new(34, 0, 16, 16), 0.0, Style::progress())
         .unwrap();
@@ -1505,12 +1507,60 @@ fn new_widgets_chart_spinner_dropdown_render_and_update() {
     gui.handle_input(InputEvent::Down).unwrap();
     assert_eq!(gui.roller_selected(roller), Some(1));
     static TABLE_ROWS: [&[&str]; 2] = [&["A", "B"], &["C", "D"]];
-    gui.add_table(Rect::new(32, 18, 40, 20), &TABLE_ROWS, Style::panel())
+    let table = gui
+        .add_table(Rect::new(32, 18, 40, 20), &TABLE_ROWS, Style::panel())
         .unwrap();
+    gui.set_table_style(table, true, 2, TextAlign::Center).unwrap();
+    let gauge = gui
+        .add_gauge(Rect::new(74, 18, 22, 22), 0.4, 0.0, 1.0, Style::progress())
+        .unwrap();
+    gui.set_gauge_ticks(gauge, 5, 2, true).unwrap();
 
     let mut target = TestBuffer::new(96, 48);
     gui.render(&mut target).unwrap();
     assert!(target.digest() != 0);
+}
+
+#[test]
+fn clipping_respects_clip_children_flag_and_scroll_marks_subtree_dirty() {
+    let mut gui = GuiContext::<8, 8, 8>::new(Rect::new(0, 0, 64, 32));
+    let parent = gui
+        .add_panel(Rect::new(4, 4, 16, 12), Style::panel())
+        .unwrap();
+    let child = gui
+        .add_label(Rect::new(14, 0, 24, 8), "OVERFLOW", Style::label())
+        .unwrap();
+    gui.add_child(parent, child).unwrap();
+    gui.clear_dirty();
+
+    let mut clipped = MockTarget::new(64, 32);
+    gui.render(&mut clipped).unwrap();
+    let clipped_outside = clipped
+        .pixels
+        .iter()
+        .any(|&(x, y, _)| x > 20 && y >= 4 && y <= 16);
+
+    gui.remove_flag(parent, WidgetFlags::CLIP_CHILDREN).unwrap();
+    let mut unclipped = MockTarget::new(64, 32);
+    gui.render(&mut unclipped).unwrap();
+    let unclipped_outside = unclipped
+        .pixels
+        .iter()
+        .any(|&(x, y, _)| x > 20 && y >= 4 && y <= 16);
+
+    assert!(!clipped_outside);
+    assert!(unclipped_outside);
+
+    let scroll = gui
+        .add_scroll_view(Rect::new(0, 20, 24, 10), 0, 30, Style::panel())
+        .unwrap();
+    let nested = gui
+        .add_label(Rect::new(1, 1, 16, 6), "SCROLL", Style::label())
+        .unwrap();
+    gui.add_child(scroll, nested).unwrap();
+    gui.clear_dirty();
+    gui.set_scroll_offset(scroll, 8).unwrap();
+    assert!(!gui.dirty_regions().is_empty());
 }
 
 #[test]
@@ -2012,6 +2062,67 @@ fn pointer_release_emits_release_events() {
 
     assert_eq!(gui.pop_event(), Some(UiEvent::Released(button)));
     assert_eq!(gui.pop_event(), Some(UiEvent::PointerReleased(button)));
+}
+
+#[test]
+fn pointer_long_press_emits_once_after_threshold() {
+    let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_long_press_threshold_ms(20);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.tick_input(19).unwrap();
+    assert_eq!(gui.pop_event(), None);
+
+    gui.tick_input(1).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::LongPressed(button)));
+    assert_eq!(gui.pop_event(), None);
+
+    gui.tick_input(50).unwrap();
+    assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn pointer_release_cancels_pending_long_press() {
+    let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
+    let _button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_long_press_threshold_ms(30);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.tick_input(10).unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.tick_input(40).unwrap();
+    assert_eq!(gui.pop_event(), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- deepen core rendering primitives by extending chart and table widgets (chart modes/decorations, table separators/padding/alignment) and exposing new context setters
- improve gauge and arc-gauge rendering with configurable major/minor ticks plus optional value text, and add APIs to tune these at runtime
- tighten container clipping and scroll dirty invalidation behavior, and add runnable showcase examples plus regression tests for long-press, dispatch, and core primitive behavior

## Test plan
- [x] `cargo check`
- [x] `cargo test --test gui`
- [x] `cargo check --example core_primitives_parity_showcase`
- [x] `cargo check --example event_dispatch_showcase`
- [x] `cargo check --example long_press_input_showcase`