### PR TITLE
Expand interaction semantics and animation presets

### DIFF
--- a/docs/animation-presets.md
+++ b/docs/animation-presets.md
@@ -1,0 +1,54 @@
+# Animation Presets Cheat-Sheet
+
+One-liner snippets for preset helpers in `embedded_gui::presets`.
+
+```rust
+use embedded_gui::prelude::*;
+```
+
+## Entrance
+
+```rust
+presets::entrance_fade_in_up(&mut animator, panel_id, 24, 12, 400)?;
+```
+
+## Attention
+
+```rust
+presets::attention_shake(&mut animator, button_id, 40, 3, 260)?;
+```
+
+## Style Motion
+
+```rust
+presets::style_breathe(&mut animator, card_id, 112, 220, 1, 4, 700)?;
+```
+
+```rust
+presets::style_accent_cycle(
+    &mut animator,
+    card_id,
+    Rgb565::new(0, 30, 20),
+    Rgb565::new(31, 50, 0),
+    800,
+)?;
+```
+
+## Path Motion
+
+```rust
+presets::path_float_loop(&mut animator, icon_id, 80, 42, 3, 900)?;
+```
+
+## Orchestration
+
+```rust
+presets::orchestrate_stagger_x(&mut animator, &[a, b, c], 8, 28, 420, 60)?;
+```
+
+## Typical Frame Loop
+
+```rust
+animator.tick(16, &mut gui)?;
+gui.render(&mut display)?;
+```

--- a/examples/animation_kitchen_sink_showcase.rs
+++ b/examples/animation_kitchen_sink_showcase.rs
@@ -1,0 +1,164 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 240;
+const H: u32 = 140;
+static TABS: [&str; 3] = ["CPU", "GFX", "NET"];
+static ITEMS: [&str; 5] = ["ONE", "TWO", "THREE", "FOUR", "FIVE"];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("animation kitchen sink showcase", &settings);
+    let mut gui = GuiContext::<32, 32, 24>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+
+    let mut animator = WidgetAnimator::<32, 32>::new();
+    start_batch(&mut animator, &ids);
+
+    'running: loop {
+        animator.tick(16, &mut gui).unwrap();
+        gui.tick_spinner(ids.spinner, 16, 0.35).unwrap();
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Space => start_batch(&mut animator, &ids),
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    progress: WidgetId,
+    meter: WidgetId,
+    slider: WidgetId,
+    scroll: WidgetId,
+    panel: WidgetId,
+    tabs: WidgetId,
+    dropdown: WidgetId,
+    roller: WidgetId,
+    gauge: WidgetId,
+    spinner: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 32, 32, 24>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 228, 128), Style::panel()).unwrap();
+    gui.add_label(
+        Rect::new(12, 10, 216, 8),
+        "SPACE restart animation batch",
+        Style::label(),
+    )
+    .unwrap();
+
+    let progress = gui
+        .add_progress_bar(Rect::new(12, 24, 92, 10), 0.0, Style::progress())
+        .unwrap();
+    let meter = gui
+        .add_meter(Rect::new(12, 38, 42, 26), 0.0, 0.0, 1.0, Style::progress())
+        .unwrap();
+    let slider = gui
+        .add_slider(Rect::new(60, 44, 44, 12), 0.0, 0.0, 1.0, Style::button())
+        .unwrap();
+    let scroll = gui
+        .add_scroll_view(Rect::new(12, 68, 92, 44), 0, 140, Style::panel())
+        .unwrap();
+    let list = gui
+        .add_list(Rect::new(4, 4, 84, 120), &ITEMS, 0, 4, Style::button())
+        .unwrap();
+    gui.add_child(scroll, list).unwrap();
+
+    let panel = gui
+        .add_panel(Rect::new(110, 24, 48, 26), Style::panel())
+        .unwrap();
+    let tabs = gui
+        .add_tabs(Rect::new(162, 24, 66, 12), &TABS, 0, Style::button())
+        .unwrap();
+    let dropdown = gui
+        .add_dropdown(Rect::new(162, 40, 66, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    let roller = gui
+        .add_roller(Rect::new(110, 54, 48, 58), &ITEMS, 0, Style::button())
+        .unwrap();
+    let gauge = gui
+        .add_gauge(Rect::new(162, 58, 34, 34), 0.0, 0.0, 1.0, Style::progress())
+        .unwrap();
+    let spinner = gui
+        .add_spinner(Rect::new(202, 58, 26, 26), 0.0, Style::progress())
+        .unwrap();
+    gui.set_gauge_ticks(gauge, 6, 2, true).unwrap();
+
+    Ids {
+        progress,
+        meter,
+        slider,
+        scroll,
+        panel,
+        tabs,
+        dropdown,
+        roller,
+        gauge,
+        spinner,
+    }
+}
+
+fn start_batch(animator: &mut WidgetAnimator<32, 32>, ids: &Ids) {
+    let _ = animator.ping_pong_progress(ids.progress, 0.05, 0.95, 1200, Easing::InOutSine);
+    let _ = animator.animate_meter(ids.meter, 0.0, 1.0, 1000, Easing::InOutCubic);
+    let _ = animator.animate_slider_value(ids.slider, 0.0, 1.0, 900, Easing::InOutSine);
+    let _ = animator.animate_scroll_offset_y(ids.scroll, 0, 80, 1200, Easing::OutCubic);
+    let _ = animator.animate_widget_x(ids.panel, 110, 128, 900, Easing::InOutBack);
+    let _ = animator.animate_widget_width(ids.panel, 48, 40, 900, Easing::InOutSine);
+    let _ = animator.animate_widget_height(ids.panel, 26, 32, 900, Easing::InOutSine);
+    let _ = animator.bind_property(
+        ids.panel,
+        AnimatedProperty::WidgetY,
+        Animation::new(24.0, 32.0, 700, Easing::InOutSine)
+            .with_repeat_mode(RepeatMode::PingPong)
+            .with_repeat_count(None),
+    );
+    let _ = animator.animate_tab_selected(ids.tabs, 0, 2, 1200, Easing::InOutSine);
+    let _ = animator.animate_dropdown_selected(ids.dropdown, 0, 4, 1200, Easing::InOutSine);
+    let _ = animator.animate_roller_selected(ids.roller, 0, 4, 1200, Easing::InOutSine);
+    let _ = animator.animate_gauge_value(ids.gauge, 0.0, 1.0, 1200, Easing::OutExpo);
+    let _ = animator.animate_spinner_phase(ids.spinner, 0.0, 2.0, 1200, Easing::Linear);
+    let _ = animator.stagger_widget_x(&[ids.tabs, ids.dropdown], 162, 168, 900, 120, Easing::OutSine);
+    let _ = animator.preset_fade_in_up(ids.panel, 32, 24, 700);
+    let _ = animator.preset_attention_shake(ids.panel, 128, 2, 700);
+    let _ = animator.animate_corner_radius(ids.panel, 0, 4, 900, Easing::InOutSine);
+    let _ = animator.animate_accent_color(
+        ids.panel,
+        Rgb565::new(0, 42, 31),
+        Rgb565::new(31, 31, 0),
+        900,
+        Easing::InOutSine,
+    );
+    let _ = animator.animate_widget_path(
+        ids.spinner,
+        &[
+            PathPoint::new(202.0, 58.0),
+            PathPoint::new(206.0, 62.0),
+            PathPoint::new(202.0, 66.0),
+            PathPoint::new(198.0, 62.0),
+            PathPoint::new(202.0, 58.0),
+        ],
+        1200,
+        Easing::InOutSine,
+    );
+}

--- a/examples/input_gesture_drag_repeat_showcase.rs
+++ b/examples/input_gesture_drag_repeat_showcase.rs
@@ -1,0 +1,242 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 240;
+const H: u32 = 140;
+static ITEMS: [&str; 10] = [
+    "ALPHA", "BETA", "GAMMA", "DELTA", "EPS", "ZETA", "ETA", "THETA", "IOTA", "KAPPA",
+];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("input gesture + drag + repeat showcase", &settings);
+    let mut gui = GuiContext::<24, 48, 24>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+
+    gui.set_long_press_threshold_ms(450);
+    gui.set_press_repeat_timing(650, 140);
+
+    let mut hold_active = false;
+    let mut drag_active = false;
+    let mut pointer_x = 18;
+    let mut pointer_y = 38;
+    let mut clicked_count = 0;
+    let mut activated_count = 0;
+    let mut long_count = 0;
+    let mut gesture_count = 0;
+
+    'running: loop {
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Space => {
+                        if !hold_active {
+                            hold_active = true;
+                            pointer_x = 18;
+                            pointer_y = 38;
+                            gui.handle_input(InputEvent::Pointer {
+                                x: pointer_x,
+                                y: pointer_y,
+                                state: PointerState::Pressed,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                        }
+                    }
+                    Keycode::Return => {
+                        if hold_active || drag_active {
+                            gui.handle_input(InputEvent::Pointer {
+                                x: pointer_x,
+                                y: pointer_y,
+                                state: PointerState::Released,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                        }
+                        hold_active = false;
+                        drag_active = false;
+                    }
+                    Keycode::D => {
+                        if !drag_active {
+                            drag_active = true;
+                            pointer_x = 142;
+                            pointer_y = 46;
+                            gui.handle_input(InputEvent::Pointer {
+                                x: pointer_x,
+                                y: pointer_y,
+                                state: PointerState::Pressed,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                        }
+                    }
+                    Keycode::Up => {
+                        if drag_active {
+                            pointer_y = (pointer_y - 6).max(36);
+                            gui.handle_input(InputEvent::Pointer {
+                                x: pointer_x,
+                                y: pointer_y,
+                                state: PointerState::Moved,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                        }
+                    }
+                    Keycode::Down => {
+                        if drag_active {
+                            pointer_y = (pointer_y + 6).min(106);
+                            gui.handle_input(InputEvent::Pointer {
+                                x: pointer_x,
+                                y: pointer_y,
+                                state: PointerState::Moved,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                        }
+                    }
+                    Keycode::Right => {
+                        if hold_active {
+                            pointer_x = (pointer_x + 8).min(118);
+                            gui.handle_input(InputEvent::Pointer {
+                                x: pointer_x,
+                                y: pointer_y,
+                                state: PointerState::Moved,
+                                button: PointerButton::Primary,
+                            })
+                            .unwrap();
+                        }
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        gui.tick_input(16).unwrap();
+        while let Some(event) = gui.pop_event() {
+            match event {
+                UiEvent::Clicked(id) if id == ids.repeat_button => {
+                    clicked_count += 1;
+                    gui.set_value_label(ids.clicked, clicked_count).unwrap();
+                }
+                UiEvent::Activate(id) if id == ids.repeat_button => {
+                    activated_count += 1;
+                    gui.set_value_label(ids.activated, activated_count).unwrap();
+                }
+                UiEvent::LongPressed(id) if id == ids.repeat_button => {
+                    long_count += 1;
+                    gui.set_value_label(ids.long_pressed, long_count).unwrap();
+                }
+                UiEvent::Gesture(id) if id == ids.repeat_button => {
+                    gesture_count += 1;
+                    gui.set_value_label(ids.gesture, gesture_count).unwrap();
+                }
+                UiEvent::Scroll { id, .. } if id == ids.scroll => {
+                    let value = gui.scroll_offset(ids.scroll).unwrap_or(0);
+                    gui.set_value_label(ids.scroll_value, value).unwrap();
+                }
+                _ => {}
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    repeat_button: WidgetId,
+    scroll: WidgetId,
+    clicked: WidgetId,
+    activated: WidgetId,
+    long_pressed: WidgetId,
+    gesture: WidgetId,
+    scroll_value: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 24, 48, 24>) -> Ids {
+    let shell = flat_style(Rgb565::new(5, 8, 20), Rgb565::new(10, 18, 26), Rgb565::new(0, 42, 31));
+    let card = flat_style(Rgb565::new(9, 14, 28), Rgb565::new(12, 22, 30), Rgb565::new(10, 56, 31));
+    let stat = flat_style(Rgb565::new(8, 10, 22), Rgb565::new(10, 18, 28), Rgb565::new(10, 56, 31));
+    let button_style = flat_style(Rgb565::new(16, 24, 31), Rgb565::new(12, 22, 30), Rgb565::new(10, 56, 31));
+
+    gui.add_panel(Rect::new(6, 6, 228, 128), shell).unwrap();
+    gui.add_label(
+        Rect::new(10, 10, 220, 8),
+        "SPACE hold  RIGHT gesture  ENTER release",
+        Style::label(),
+    )
+    .unwrap();
+    gui.add_label(
+        Rect::new(10, 20, 220, 8),
+        "D drag mode  UP/DOWN drag-scroll",
+        Style::label(),
+    )
+    .unwrap();
+
+    let repeat_button = gui
+        .add_button(Rect::new(12, 34, 112, 16), "HOLD TARGET", button_style)
+        .unwrap();
+
+    let clicked = gui
+        .add_value_label(Rect::new(12, 54, 54, 12), "CLICK", 0, stat)
+        .unwrap();
+    let activated = gui
+        .add_value_label(Rect::new(70, 54, 54, 12), "ACT", 0, stat)
+        .unwrap();
+    let long_pressed = gui
+        .add_value_label(Rect::new(12, 70, 54, 12), "LONG", 0, stat)
+        .unwrap();
+    let gesture = gui
+        .add_value_label(Rect::new(70, 70, 54, 12), "GEST", 0, stat)
+        .unwrap();
+
+    let scroll = gui
+        .add_scroll_view(Rect::new(136, 34, 92, 72), 0, 180, card)
+        .unwrap();
+    let list = gui
+        .add_list(Rect::new(4, 4, 84, 160), &ITEMS, 0, 8, card)
+        .unwrap();
+    gui.add_child(scroll, list).unwrap();
+    let scroll_value = gui
+        .add_value_label(Rect::new(136, 110, 92, 12), "SCROLL", 0, stat)
+        .unwrap();
+
+    Ids {
+        repeat_button,
+        scroll,
+        clicked,
+        activated,
+        long_pressed,
+        gesture,
+        scroll_value,
+    }
+}
+
+fn flat_style(background: Rgb565, border: Rgb565, accent: Rgb565) -> Style {
+    Style {
+        background: Some(background),
+        gradient: None,
+        font: FontId::Medium4x7,
+        foreground: Rgb565::WHITE,
+        text: Rgb565::WHITE,
+        accent,
+        opacity: 255,
+        corner_radius: 1,
+        shadow: None,
+        border: Border::one(border),
+        padding: EdgeInsets::all(1),
+    }
+}

--- a/src/context.rs
+++ b/src/context.rs
@@ -33,11 +33,24 @@ impl From<DirtyError> for GuiError {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 struct PressTracker {
     id: WidgetId,
+    start_x: i32,
+    start_y: i32,
+    last_x: i32,
+    last_y: i32,
     elapsed_ms: u32,
     long_emitted: bool,
+    gesture_emitted: bool,
+    repeat_elapsed_ms: u32,
+    scroll_velocity: f32,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct InertiaScroll {
+    id: WidgetId,
+    velocity: f32,
 }
 
 pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize> {
@@ -53,7 +66,10 @@ pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: 
     active_focus_group: Option<FocusGroupId>,
     render_quality: RenderQuality,
     long_press_ms: u32,
+    press_repeat_delay_ms: u32,
+    press_repeat_interval_ms: u32,
     pressed: Option<PressTracker>,
+    inertia_scroll: Option<InertiaScroll>,
     next_id: u16,
 }
 
@@ -76,7 +92,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             active_focus_group: None,
             render_quality: RenderQuality::High,
             long_press_ms: 500,
+            press_repeat_delay_ms: 650,
+            press_repeat_interval_ms: 140,
             pressed: None,
+            inertia_scroll: None,
             next_id: 1,
         }
     }
@@ -98,6 +117,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.class_styles.clear();
         self.focus = None;
         self.pressed = None;
+        self.inertia_scroll = None;
         self.dirty.mark_all(self.viewport)?;
         Ok(())
     }
@@ -108,6 +128,11 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
 
     pub fn set_long_press_threshold_ms(&mut self, threshold_ms: u32) {
         self.long_press_ms = threshold_ms.max(1);
+    }
+
+    pub fn set_press_repeat_timing(&mut self, delay_ms: u32, interval_ms: u32) {
+        self.press_repeat_delay_ms = delay_ms.max(1);
+        self.press_repeat_interval_ms = interval_ms.max(1);
     }
 
     pub fn widgets(&self) -> &[WidgetNode<'a>] {
@@ -797,7 +822,15 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         S: Into<WidgetStyle>,
     {
         let selected = selected.min(items.len().saturating_sub(1));
-        let id = self.add_widget(rect, WidgetKind::Dropdown { items, selected }, style)?;
+        let id = self.add_widget(
+            rect,
+            WidgetKind::Dropdown {
+                items,
+                selected,
+                open: false,
+            },
+            style,
+        )?;
         self.ensure_focus();
         Ok(id)
     }
@@ -1235,6 +1268,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             WidgetKind::Dropdown {
                 items,
                 selected: ref mut current,
+                ..
             } => {
                 *current = selected.min(items.len().saturating_sub(1));
                 self.dirty.add(rect)?;
@@ -1247,6 +1281,36 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     pub fn dropdown_selected(&self, id: WidgetId) -> Option<usize> {
         match self.node(id)?.kind {
             WidgetKind::Dropdown { selected, .. } => Some(selected),
+            _ => None,
+        }
+    }
+
+    pub fn set_dropdown_open(&mut self, id: WidgetId, open: bool) -> Result<(), GuiError> {
+        let rect = self.absolute_rect(id).ok_or(GuiError::NotFound)?;
+        let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
+        match node.kind {
+            WidgetKind::Dropdown {
+                open: ref mut is_open,
+                ..
+            } => {
+                if *is_open != open {
+                    *is_open = open;
+                    self.dirty.add(rect)?;
+                    self.push_event(if open {
+                        UiEvent::Opened(id)
+                    } else {
+                        UiEvent::Closed(id)
+                    })?;
+                }
+                Ok(())
+            }
+            _ => Err(GuiError::NotFound),
+        }
+    }
+
+    pub fn dropdown_open(&self, id: WidgetId) -> Option<bool> {
+        match self.node(id)?.kind {
+            WidgetKind::Dropdown { open, .. } => Some(open),
             _ => None,
         }
     }
@@ -1326,6 +1390,20 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             WidgetKind::TextArea { cursor, .. } => Some(cursor),
             _ => None,
         }
+    }
+
+    pub fn textarea_insert_char(&mut self, id: WidgetId, ch: char) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        self.push_event(UiEvent::TextInput { id, ch })?;
+        self.push_event(UiEvent::ValueChanged(id))
+    }
+
+    pub fn textarea_backspace(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        self.textarea_insert_char(id, '\u{8}')
+    }
+
+    pub fn textarea_delete_forward(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        self.textarea_insert_char(id, '\u{7f}')
     }
 
     pub fn keyboard_selected_key(&self, id: WidgetId) -> Option<char> {
@@ -1483,6 +1561,24 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         node.style.focused.opacity = opacity;
         node.style.pressed.opacity = opacity;
         node.style.disabled.opacity = opacity;
+        self.mark_subtree_dirty(id)
+    }
+
+    pub fn set_widget_corner_radius(&mut self, id: WidgetId, radius: u8) -> Result<(), GuiError> {
+        let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
+        node.style.normal.corner_radius = radius;
+        node.style.focused.corner_radius = radius;
+        node.style.pressed.corner_radius = radius;
+        node.style.disabled.corner_radius = radius;
+        self.mark_subtree_dirty(id)
+    }
+
+    pub fn set_widget_accent(&mut self, id: WidgetId, accent: Rgb565) -> Result<(), GuiError> {
+        let node = self.node_mut(id).ok_or(GuiError::NotFound)?;
+        node.style.normal.accent = accent;
+        node.style.focused.accent = accent;
+        node.style.pressed.accent = accent;
+        node.style.disabled.accent = accent;
         self.mark_subtree_dirty(id)
     }
 
@@ -1915,7 +2011,15 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 }
                 Ok(())
             }
-            InputEvent::Back => self.push_event(UiEvent::Back),
+            InputEvent::Back => {
+                if let Some(id) = self.focus {
+                    if matches!(self.node(id).map(|n| n.kind), Some(WidgetKind::TextArea { .. })) {
+                        self.textarea_backspace(id)?;
+                        return Ok(());
+                    }
+                }
+                self.push_event(UiEvent::Back)
+            }
             InputEvent::Pointer {
                 x,
                 y,
@@ -1928,29 +2032,64 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 state: PointerState::Released,
                 ..
             } => self.handle_pointer_released(x, y),
+            InputEvent::Pointer {
+                x,
+                y,
+                state: PointerState::Moved,
+                ..
+            } => self.handle_pointer_moved(x, y),
             _ => Ok(()),
         }
     }
 
     pub fn tick_input(&mut self, dt_ms: u32) -> Result<(), GuiError> {
+        if let Some(mut inertia) = self.inertia_scroll {
+            if inertia.velocity.abs() < 0.05 {
+                self.inertia_scroll = None;
+            } else {
+                let current = self.scroll_offset(inertia.id).unwrap_or(0);
+                let delta = (inertia.velocity * (dt_ms as f32 / 16.0)).round() as i32;
+                if delta != 0 {
+                    let next = current.saturating_sub(delta);
+                    if next != current {
+                        self.set_scroll_offset(inertia.id, next)?;
+                        self.push_event(UiEvent::Scroll {
+                            id: inertia.id,
+                            delta: next - current,
+                        })?;
+                    }
+                }
+                inertia.velocity *= 0.86f32.powf((dt_ms as f32 / 16.0).max(1.0));
+                self.inertia_scroll = Some(inertia);
+            }
+        }
         let Some(mut pressed) = self.pressed else {
             return Ok(());
         };
-        if pressed.long_emitted {
-            return Ok(());
-        }
         if !self.effective_visible(pressed.id) || !self.effective_enabled(pressed.id) {
             self.pressed = None;
             return Ok(());
         }
         pressed.elapsed_ms = pressed.elapsed_ms.saturating_add(dt_ms);
-        if pressed.elapsed_ms >= self.long_press_ms {
+        pressed.repeat_elapsed_ms = pressed.repeat_elapsed_ms.saturating_add(dt_ms);
+        if !pressed.long_emitted && pressed.elapsed_ms >= self.long_press_ms {
             let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
             self.dispatch_widget_event(pressed.id, WidgetEventKind::LongPressed, &mut events, |_| {
                 EventPolicy::Continue
             })?;
             self.push_event(UiEvent::LongPressed(pressed.id))?;
             pressed.long_emitted = true;
+        }
+        if pressed.repeat_elapsed_ms >= self.press_repeat_delay_ms
+            && self.repeatable_widget(pressed.id)
+            && pressed.long_emitted
+        {
+            let intervals = (pressed.repeat_elapsed_ms - self.press_repeat_delay_ms)
+                / self.press_repeat_interval_ms;
+            if intervals > 0 {
+                self.dispatch_repeat_activation(pressed.id)?;
+                pressed.repeat_elapsed_ms = self.press_repeat_delay_ms;
+            }
         }
         self.pressed = Some(pressed);
         Ok(())
@@ -2165,7 +2304,9 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 text_width(text).saturating_add(8),
                 text_height.saturating_add(2),
             ),
-            WidgetKind::Dropdown { items, selected } => (
+            WidgetKind::Dropdown {
+                items, selected, ..
+            } => (
                 text_width(items.get(selected).copied().unwrap_or("-")).saturating_add(10),
                 text_height.saturating_add(2),
             ),
@@ -2368,7 +2509,11 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 WidgetKind::Dropdown {
                     items,
                     selected: ref mut current,
+                    open,
                 } => {
+                    if !open {
+                        return Ok(false);
+                    }
                     if items.is_empty() {
                         return Ok(true);
                     }
@@ -2498,6 +2643,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     fn activate_focused(&mut self, id: WidgetId) -> Result<(), GuiError> {
         let mut changed_rect = None;
         let mut changed = false;
+        let mut dropdown_state_event = None;
 
         if let Some(node) = self.node_mut(id) {
             match node.kind {
@@ -2530,8 +2676,36 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                         }
                     }
                 }
+                WidgetKind::Dropdown {
+                    open: ref mut is_open,
+                    ..
+                } => {
+                    *is_open = !*is_open;
+                    changed = true;
+                    changed_rect = Some(node.rect);
+                    dropdown_state_event = Some(*is_open);
+                }
                 _ => {}
             }
+        }
+
+        if let Some(open) = dropdown_state_event {
+            let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+            self.dispatch_widget_event(
+                id,
+                if open {
+                    WidgetEventKind::Opened
+                } else {
+                    WidgetEventKind::Closed
+                },
+                &mut events,
+                |_| EventPolicy::Continue,
+            )?;
+            self.push_event(if open {
+                UiEvent::Opened(id)
+            } else {
+                UiEvent::Closed(id)
+            })?;
         }
 
         if let Some(rect) = changed_rect {
@@ -2549,46 +2723,40 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     }
 
     fn handle_pointer_pressed(&mut self, x: i32, y: i32) -> Result<(), GuiError> {
-        let hit = self
-            .widgets
-            .iter()
-            .rev()
-            .find(|node| {
-                node.clickable()
-                    && self.effective_visible(node.id)
-                    && self.effective_enabled(node.id)
-                    && self
-                        .absolute_rect(node.id)
-                        .is_some_and(|rect| rect.contains(x, y))
-            })
-            .map(|node| node.id);
+        let hit = self.pointer_hit(x, y, true);
 
         if let Some(id) = hit {
             self.dispatch_activation(id, true)?;
             self.pressed = Some(PressTracker {
                 id,
+                start_x: x,
+                start_y: y,
+                last_x: x,
+                last_y: y,
                 elapsed_ms: 0,
                 long_emitted: false,
+                gesture_emitted: false,
+                repeat_elapsed_ms: 0,
+                scroll_velocity: 0.0,
             });
+            self.inertia_scroll = None;
         }
         Ok(())
     }
 
     fn handle_pointer_released(&mut self, x: i32, y: i32) -> Result<(), GuiError> {
+        if let Some(pressed) = self.pressed {
+            if let Some(scroll_id) = self.scrollable_ancestor(pressed.id) {
+                if pressed.scroll_velocity.abs() > 0.2 {
+                    self.inertia_scroll = Some(InertiaScroll {
+                        id: scroll_id,
+                        velocity: pressed.scroll_velocity,
+                    });
+                }
+            }
+        }
         self.pressed = None;
-        let hit = self
-            .widgets
-            .iter()
-            .rev()
-            .find(|node| {
-                node.clickable()
-                    && self.effective_visible(node.id)
-                    && self.effective_enabled(node.id)
-                    && self
-                        .absolute_rect(node.id)
-                        .is_some_and(|rect| rect.contains(x, y))
-            })
-            .map(|node| node.id);
+        let hit = self.pointer_hit(x, y, true);
         if let Some(id) = hit {
             let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
             self.dispatch_widget_event(id, WidgetEventKind::Released, &mut events, |_| {
@@ -2597,6 +2765,50 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             self.push_event(UiEvent::Released(id))?;
             self.push_event(UiEvent::PointerReleased(id))?;
         }
+        Ok(())
+    }
+
+    fn handle_pointer_moved(&mut self, x: i32, y: i32) -> Result<(), GuiError> {
+        let Some(mut pressed) = self.pressed else {
+            return Ok(());
+        };
+        let dy = y - pressed.last_y;
+        pressed.last_x = x;
+        pressed.last_y = y;
+
+        let moved_from_start =
+            (x - pressed.start_x).unsigned_abs() + (y - pressed.start_y).unsigned_abs();
+        if !pressed.gesture_emitted && moved_from_start >= 6 {
+            let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+            self.dispatch_widget_event(pressed.id, WidgetEventKind::Gesture, &mut events, |_| {
+                EventPolicy::Continue
+            })?;
+            self.push_event(UiEvent::Gesture(pressed.id))?;
+            pressed.gesture_emitted = true;
+        }
+
+        if let Some(scroll_id) = self.scrollable_ancestor(pressed.id) {
+            let current = self.scroll_offset(scroll_id).unwrap_or(0);
+            let next = current.saturating_sub(dy);
+            if next != current {
+                self.set_scroll_offset(scroll_id, next)?;
+                self.push_event(UiEvent::Scroll {
+                    id: scroll_id,
+                    delta: next - current,
+                })?;
+                let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+                self.dispatch_widget_event(
+                    scroll_id,
+                    WidgetEventKind::Scroll {
+                        delta: next - current,
+                    },
+                    &mut events,
+                    |_| EventPolicy::Continue,
+                )?;
+            }
+            pressed.scroll_velocity = pressed.scroll_velocity * 0.6 + (dy as f32) * 0.4;
+        }
+        self.pressed = Some(pressed);
         Ok(())
     }
 
@@ -2620,6 +2832,53 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.push_event(UiEvent::Clicked(id))?;
         self.push_event(UiEvent::Activate(id))?;
         Ok(())
+    }
+
+    fn dispatch_repeat_activation(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+        self.dispatch_widget_event(id, WidgetEventKind::Clicked, &mut events, |_| {
+            EventPolicy::Continue
+        })?;
+        self.push_event(UiEvent::Clicked(id))?;
+        self.push_event(UiEvent::Activate(id))
+    }
+
+    fn repeatable_widget(&self, id: WidgetId) -> bool {
+        self.node(id).is_some_and(|node| {
+            matches!(node.kind, WidgetKind::Button(_) | WidgetKind::IconButton { .. })
+        })
+    }
+
+    fn pointer_hit(&self, x: i32, y: i32, clickable_only: bool) -> Option<WidgetId> {
+        self.widgets
+            .iter()
+            .rev()
+            .find(|node| {
+                (!clickable_only || node.clickable())
+                    && self.effective_visible(node.id)
+                    && self.effective_enabled(node.id)
+                    && self
+                        .absolute_rect(node.id)
+                        .is_some_and(|rect| rect.contains(x, y))
+            })
+            .map(|node| node.id)
+    }
+
+    fn scrollable_ancestor(&self, id: WidgetId) -> Option<WidgetId> {
+        let mut current = Some(id);
+        let mut depth = 0usize;
+        while let Some(widget_id) = current {
+            if depth >= NODES {
+                return None;
+            }
+            let node = self.node(widget_id)?;
+            if node.scrollable() {
+                return Some(widget_id);
+            }
+            current = node.parent;
+            depth += 1;
+        }
+        None
     }
 
     fn mark_focus_pair(

--- a/src/input.rs
+++ b/src/input.rs
@@ -44,8 +44,11 @@ pub enum UiEvent {
     Released(WidgetId),
     Clicked(WidgetId),
     LongPressed(WidgetId),
+    Opened(WidgetId),
+    Closed(WidgetId),
     PointerPressed(WidgetId),
     PointerReleased(WidgetId),
+    Gesture(WidgetId),
     ValueChanged(WidgetId),
     TextInput {
         id: WidgetId,
@@ -119,8 +122,11 @@ impl UiEvent {
             | Self::Released(id)
             | Self::Clicked(id)
             | Self::LongPressed(id)
+            | Self::Opened(id)
+            | Self::Closed(id)
             | Self::PointerPressed(id)
             | Self::PointerReleased(id)
+            | Self::Gesture(id)
             | Self::ValueChanged(id)
             | Self::TextInput { id, .. }
             | Self::Focused(id)
@@ -141,9 +147,13 @@ impl UiEvent {
             | Self::Pressed(_)
             | Self::Released(_)
             | Self::Clicked(_)
-            | Self::LongPressed(_) => UiEventFilter::ACTIVATE,
+            | Self::LongPressed(_)
+            | Self::Opened(_)
+            | Self::Closed(_) => UiEventFilter::ACTIVATE,
             Self::Back => UiEventFilter::BACK,
-            Self::PointerPressed(_) | Self::PointerReleased(_) => UiEventFilter::POINTER,
+            Self::PointerPressed(_) | Self::PointerReleased(_) | Self::Gesture(_) => {
+                UiEventFilter::POINTER
+            }
             Self::ValueChanged(_) | Self::TextInput { .. } => UiEventFilter::VALUE,
             Self::Scroll { .. } => UiEventFilter::SCROLL,
             Self::LayoutChanged(_) => UiEventFilter::LAYOUT,
@@ -158,6 +168,8 @@ pub enum WidgetEventKind {
     Released,
     Clicked,
     LongPressed,
+    Opened,
+    Closed,
     ValueChanged,
     Focused,
     Defocused,
@@ -214,7 +226,9 @@ impl WidgetEventKind {
     pub const fn filter(self) -> WidgetEventFilter {
         match self {
             Self::Pressed | Self::Released | Self::Gesture => WidgetEventFilter::POINTER,
-            Self::Clicked | Self::LongPressed => WidgetEventFilter::ACTIVATE,
+            Self::Clicked | Self::LongPressed | Self::Opened | Self::Closed => {
+                WidgetEventFilter::ACTIVATE
+            }
             Self::ValueChanged => WidgetEventFilter::VALUE,
             Self::Focused | Self::Defocused => WidgetEventFilter::FOCUS,
             Self::Scroll { .. } => WidgetEventFilter::SCROLL,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,6 +81,7 @@ pub use widget_animation::{
     AnimatedProperty, AnimationConflictPolicy, BindingSnapshot, WidgetAnimationCallbacks,
     WidgetAnimationError, WidgetAnimator,
 };
+pub use widget_animation::presets;
 pub use widgets::{ChartMode, KeyboardLayout, WidgetKind, WidgetNode};
 
 pub mod prelude {
@@ -107,6 +108,7 @@ pub mod prelude {
         AnimationConflictPolicy, BindingSnapshot, WidgetDispatchPolicy, WidgetEvent,
         WidgetEventFilter, WidgetEventKind, WidgetFlags, WidgetId, WidgetKind, WidgetStyle, KeyboardLayout,
         ChartMode,
+        presets,
         TextShaper, BasicTextShaper, ShapingConfig, ShapedGlyph, TextDirection,
         apply_easing,
     };

--- a/src/render.rs
+++ b/src/render.rs
@@ -1386,10 +1386,9 @@ where
             }
             FontId::Medium4x7 => {
                 for (row, bits) in glyph.iter().enumerate() {
-                    let y_row = row as i32 + (row as i32 / 2);
                     for col in 0..3 {
                         if bits & (1 << (2 - col)) != 0 {
-                            self.pixel(x + col, y + y_row, color, opacity)?;
+                            self.pixel(x + col, y + row as i32, color, opacity)?;
                         }
                     }
                 }

--- a/src/widget_animation.rs
+++ b/src/widget_animation.rs
@@ -2,9 +2,10 @@
 //! Keeps fixed-capacity, no-allocation behavior suitable for embedded targets.
 
 use heapless::Vec;
+use embedded_graphics_core::pixelcolor::{Rgb565, RgbColor};
 
 use crate::{
-    animation::{Animation, AnimationError, AnimationId, AnimationManager, Easing},
+    animation::{Animation, AnimationError, AnimationId, AnimationManager, Easing, PathPoint},
     context::{GuiContext, GuiError},
     widget::WidgetId,
 };
@@ -22,6 +23,15 @@ pub enum AnimatedProperty {
     Meter,
     SliderValue,
     ScrollOffsetY,
+    TabSelected,
+    DropdownSelected,
+    RollerSelected,
+    GaugeValue,
+    SpinnerPhase,
+    CornerRadius,
+    AccentR,
+    AccentG,
+    AccentB,
     WidgetX,
     WidgetY,
     WidgetWidth,
@@ -188,6 +198,81 @@ impl<const TRACKS: usize, const BINDINGS: usize> WidgetAnimator<TRACKS, BINDINGS
             AnimatedProperty::ScrollOffsetY,
             Animation::new(from as f32, to as f32, duration_ms, easing),
             policy,
+        )
+    }
+
+    pub fn animate_tab_selected(
+        &mut self,
+        widget_id: WidgetId,
+        from: usize,
+        to: usize,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        self.bind_property(
+            widget_id,
+            AnimatedProperty::TabSelected,
+            Animation::new(from as f32, to as f32, duration_ms, easing),
+        )
+    }
+
+    pub fn animate_dropdown_selected(
+        &mut self,
+        widget_id: WidgetId,
+        from: usize,
+        to: usize,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        self.bind_property(
+            widget_id,
+            AnimatedProperty::DropdownSelected,
+            Animation::new(from as f32, to as f32, duration_ms, easing),
+        )
+    }
+
+    pub fn animate_roller_selected(
+        &mut self,
+        widget_id: WidgetId,
+        from: usize,
+        to: usize,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        self.bind_property(
+            widget_id,
+            AnimatedProperty::RollerSelected,
+            Animation::new(from as f32, to as f32, duration_ms, easing),
+        )
+    }
+
+    pub fn animate_gauge_value(
+        &mut self,
+        widget_id: WidgetId,
+        from: f32,
+        to: f32,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        self.bind_property(
+            widget_id,
+            AnimatedProperty::GaugeValue,
+            Animation::new(from, to, duration_ms, easing),
+        )
+    }
+
+    pub fn animate_spinner_phase(
+        &mut self,
+        widget_id: WidgetId,
+        from: f32,
+        to: f32,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        self.bind_property(
+            widget_id,
+            AnimatedProperty::SpinnerPhase,
+            Animation::new(from, to, duration_ms, easing),
         )
     }
 
@@ -364,6 +449,263 @@ impl<const TRACKS: usize, const BINDINGS: usize> WidgetAnimator<TRACKS, BINDINGS
             Animation::new(from as f32, to as f32, duration_ms, easing),
             policy,
         )
+    }
+
+    pub fn pulse_opacity(
+        &mut self,
+        widget_id: WidgetId,
+        low: u8,
+        high: u8,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        let animation = Animation::new(low as f32, high as f32, duration_ms, easing)
+            .with_repeat_mode(crate::animation::RepeatMode::PingPong)
+            .with_repeat_count(None);
+        self.bind_property(widget_id, AnimatedProperty::Opacity, animation)
+    }
+
+    pub fn ping_pong_progress(
+        &mut self,
+        widget_id: WidgetId,
+        from: f32,
+        to: f32,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        let animation = Animation::new(from, to, duration_ms, easing)
+            .with_repeat_mode(crate::animation::RepeatMode::PingPong)
+            .with_repeat_count(None);
+        self.bind_property(widget_id, AnimatedProperty::Progress, animation)
+    }
+
+    pub fn animate_corner_radius(
+        &mut self,
+        widget_id: WidgetId,
+        from: u8,
+        to: u8,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<AnimationId, WidgetAnimationError> {
+        self.bind_property(
+            widget_id,
+            AnimatedProperty::CornerRadius,
+            Animation::new(from as f32, to as f32, duration_ms, easing),
+        )
+    }
+
+    pub fn animate_accent_color(
+        &mut self,
+        widget_id: WidgetId,
+        from: Rgb565,
+        to: Rgb565,
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<[AnimationId; 3], WidgetAnimationError> {
+        let mut ids = [AnimationId::new(0); 3];
+        let mut started = Vec::<AnimationId, 3>::new();
+        let r = self.bind_property(
+            widget_id,
+            AnimatedProperty::AccentR,
+            Animation::new(from.r() as f32, to.r() as f32, duration_ms, easing),
+        )?;
+        ids[0] = r;
+        let _ = started.push(r);
+        let g = match self.bind_property(
+            widget_id,
+            AnimatedProperty::AccentG,
+            Animation::new(from.g() as f32, to.g() as f32, duration_ms, easing),
+        ) {
+            Ok(v) => v,
+            Err(err) => {
+                for id in started {
+                    let _ = self.stop(id);
+                }
+                return Err(err);
+            }
+        };
+        ids[1] = g;
+        let _ = started.push(g);
+        let b = match self.bind_property(
+            widget_id,
+            AnimatedProperty::AccentB,
+            Animation::new(from.b() as f32, to.b() as f32, duration_ms, easing),
+        ) {
+            Ok(v) => v,
+            Err(err) => {
+                for id in started {
+                    let _ = self.stop(id);
+                }
+                return Err(err);
+            }
+        };
+        ids[2] = b;
+        Ok(ids)
+    }
+
+    pub fn animate_widget_path(
+        &mut self,
+        widget_id: WidgetId,
+        points: &[PathPoint],
+        duration_ms: u32,
+        easing: Easing,
+    ) -> Result<(AnimationId, AnimationId), WidgetAnimationError> {
+        self.animate_widget_path_with_policy(
+            widget_id,
+            points,
+            duration_ms,
+            easing,
+            AnimationConflictPolicy::Replace,
+        )
+    }
+
+    pub fn animate_widget_path_with_policy(
+        &mut self,
+        widget_id: WidgetId,
+        points: &[PathPoint],
+        duration_ms: u32,
+        easing: Easing,
+        policy: AnimationConflictPolicy,
+    ) -> Result<(AnimationId, AnimationId), WidgetAnimationError> {
+        if points.len() < 2 {
+            return Err(WidgetAnimationError::ConflictIgnored);
+        }
+        let segs = (points.len() - 1) as u32;
+        let seg_duration = (duration_ms / segs).max(1);
+        let mut ids = Vec::<AnimationId, BINDINGS>::new();
+        let mut first_x = AnimationId::new(0);
+        let mut first_y = AnimationId::new(0);
+
+        for i in 0..(points.len() - 1) {
+            let from = points[i];
+            let to = points[i + 1];
+            let delay = seg_duration.saturating_mul(i as u32);
+            let x_anim = Animation::new(from.x, to.x, seg_duration, easing).with_delay(delay);
+            let y_anim = Animation::new(from.y, to.y, seg_duration, easing).with_delay(delay);
+            let step_policy = if i == 0 {
+                policy
+            } else {
+                AnimationConflictPolicy::Queue
+            };
+            let x_id = match self.bind_property_with_policy(
+                widget_id,
+                AnimatedProperty::WidgetX,
+                x_anim,
+                step_policy,
+            ) {
+                Ok(id) => id,
+                Err(err) => {
+                    for id in ids {
+                        let _ = self.stop(id);
+                    }
+                    return Err(err);
+                }
+            };
+            let _ = ids.push(x_id);
+            let y_id = match self.bind_property_with_policy(
+                widget_id,
+                AnimatedProperty::WidgetY,
+                y_anim,
+                step_policy,
+            ) {
+                Ok(id) => id,
+                Err(err) => {
+                    for id in ids {
+                        let _ = self.stop(id);
+                    }
+                    return Err(err);
+                }
+            };
+            let _ = ids.push(y_id);
+            if i == 0 {
+                first_x = x_id;
+                first_y = y_id;
+            }
+        }
+        Ok((first_x, first_y))
+    }
+
+    pub fn stagger_widget_x(
+        &mut self,
+        widget_ids: &[WidgetId],
+        from: i32,
+        to: i32,
+        duration_ms: u32,
+        stagger_ms: u32,
+        easing: Easing,
+    ) -> Result<usize, WidgetAnimationError> {
+        let mut created = 0usize;
+        let mut started = Vec::<AnimationId, BINDINGS>::new();
+        for (idx, id) in widget_ids.iter().copied().enumerate() {
+            let delay = stagger_ms.saturating_mul(idx as u32);
+            let animation = Animation::new(from as f32, to as f32, duration_ms, easing).with_delay(delay);
+            match self.bind_property_with_policy(
+                id,
+                AnimatedProperty::WidgetX,
+                animation,
+                AnimationConflictPolicy::Replace,
+            ) {
+                Ok(track) => {
+                    let _ = started.push(track);
+                    created += 1;
+                }
+                Err(err) => {
+                    for track in started {
+                        let _ = self.stop(track);
+                    }
+                    return Err(err);
+                }
+            }
+        }
+        Ok(created)
+    }
+
+    pub fn preset_fade_in_up(
+        &mut self,
+        widget_id: WidgetId,
+        from_y: i32,
+        to_y: i32,
+        duration_ms: u32,
+    ) -> Result<(AnimationId, AnimationId), WidgetAnimationError> {
+        let y = self.animate_widget_y(widget_id, from_y, to_y, duration_ms, Easing::OutCubic)?;
+        let alpha = self.animate_opacity(widget_id, 0, 255, duration_ms, Easing::OutSine)?;
+        Ok((y, alpha))
+    }
+
+    pub fn preset_attention_shake(
+        &mut self,
+        widget_id: WidgetId,
+        base_x: i32,
+        amplitude: i32,
+        duration_ms: u32,
+    ) -> Result<(AnimationId, AnimationId), WidgetAnimationError> {
+        let step = (duration_ms / 3).max(1);
+        let a = self.bind_property_with_policy(
+            widget_id,
+            AnimatedProperty::WidgetX,
+            Animation::new(base_x as f32, (base_x + amplitude) as f32, step, Easing::InOutSine),
+            AnimationConflictPolicy::Replace,
+        )?;
+        let b = self.bind_property_with_policy(
+            widget_id,
+            AnimatedProperty::WidgetX,
+            Animation::new(
+                (base_x + amplitude) as f32,
+                (base_x - amplitude) as f32,
+                step,
+                Easing::InOutSine,
+            )
+            .with_delay(step),
+            AnimationConflictPolicy::Queue,
+        )?;
+        self.bind_property_with_policy(
+            widget_id,
+            AnimatedProperty::WidgetX,
+            Animation::new((base_x - amplitude) as f32, base_x as f32, step, Easing::InOutSine)
+                .with_delay(step.saturating_mul(2)),
+            AnimationConflictPolicy::Queue,
+        )?;
+        Ok((a, b))
     }
 
     pub fn bind_property_with_policy(
@@ -576,6 +918,56 @@ impl<const TRACKS: usize, const BINDINGS: usize> WidgetAnimator<TRACKS, BINDINGS
                 AnimatedProperty::ScrollOffsetY => {
                     gui.set_scroll_offset(binding.widget_id, value.round() as i32)?
                 }
+                AnimatedProperty::TabSelected => {
+                    gui.set_tab_selected(binding.widget_id, value.max(0.0).round() as usize)?
+                }
+                AnimatedProperty::DropdownSelected => {
+                    gui.set_dropdown_selected(binding.widget_id, value.max(0.0).round() as usize)?
+                }
+                AnimatedProperty::RollerSelected => {
+                    gui.set_roller_selected(binding.widget_id, value.max(0.0).round() as usize)?
+                }
+                AnimatedProperty::GaugeValue => gui.set_gauge_value(binding.widget_id, value)?,
+                AnimatedProperty::SpinnerPhase => gui.set_spinner_phase(binding.widget_id, value)?,
+                AnimatedProperty::CornerRadius => gui.set_widget_corner_radius(
+                    binding.widget_id,
+                    value.clamp(0.0, 255.0).round() as u8,
+                )?,
+                AnimatedProperty::AccentR
+                | AnimatedProperty::AccentG
+                | AnimatedProperty::AccentB => {
+                    let node = gui
+                        .widgets()
+                        .iter()
+                        .find(|node| node.id == binding.widget_id)
+                        .ok_or(GuiError::NotFound)?;
+                    let mut accent = node.style.normal.accent;
+                    match binding.property {
+                        AnimatedProperty::AccentR => {
+                            accent = Rgb565::new(
+                                value.clamp(0.0, 31.0).round() as u8,
+                                accent.g(),
+                                accent.b(),
+                            );
+                        }
+                        AnimatedProperty::AccentG => {
+                            accent = Rgb565::new(
+                                accent.r(),
+                                value.clamp(0.0, 63.0).round() as u8,
+                                accent.b(),
+                            );
+                        }
+                        AnimatedProperty::AccentB => {
+                            accent = Rgb565::new(
+                                accent.r(),
+                                accent.g(),
+                                value.clamp(0.0, 31.0).round() as u8,
+                            );
+                        }
+                        _ => {}
+                    }
+                    gui.set_widget_accent(binding.widget_id, accent)?;
+                }
                 AnimatedProperty::WidgetX => gui.set_widget_x(binding.widget_id, value.round() as i32)?,
                 AnimatedProperty::WidgetY => gui.set_widget_y(binding.widget_id, value.round() as i32)?,
                 AnimatedProperty::WidgetWidth => {
@@ -607,5 +999,100 @@ impl<const TRACKS: usize, const BINDINGS: usize> WidgetAnimator<TRACKS, BINDINGS
 impl From<AnimationError> for WidgetAnimationError {
     fn from(_: AnimationError) -> Self {
         Self::AnimationsFull
+    }
+}
+
+pub mod presets {
+    use embedded_graphics_core::pixelcolor::Rgb565;
+
+    use super::{Easing, PathPoint, WidgetAnimationError, WidgetAnimator, WidgetId};
+
+    pub fn entrance_fade_in_up<const TRACKS: usize, const BINDINGS: usize>(
+        animator: &mut WidgetAnimator<TRACKS, BINDINGS>,
+        widget_id: WidgetId,
+        from_y: i32,
+        to_y: i32,
+        duration_ms: u32,
+    ) -> Result<(), WidgetAnimationError> {
+        animator.preset_fade_in_up(widget_id, from_y, to_y, duration_ms)?;
+        Ok(())
+    }
+
+    pub fn attention_shake<const TRACKS: usize, const BINDINGS: usize>(
+        animator: &mut WidgetAnimator<TRACKS, BINDINGS>,
+        widget_id: WidgetId,
+        base_x: i32,
+        amplitude: i32,
+        duration_ms: u32,
+    ) -> Result<(), WidgetAnimationError> {
+        animator.preset_attention_shake(widget_id, base_x, amplitude, duration_ms)?;
+        Ok(())
+    }
+
+    pub fn style_breathe<const TRACKS: usize, const BINDINGS: usize>(
+        animator: &mut WidgetAnimator<TRACKS, BINDINGS>,
+        widget_id: WidgetId,
+        low_opacity: u8,
+        high_opacity: u8,
+        low_radius: u8,
+        high_radius: u8,
+        duration_ms: u32,
+    ) -> Result<(), WidgetAnimationError> {
+        animator.pulse_opacity(
+            widget_id,
+            low_opacity,
+            high_opacity,
+            duration_ms,
+            Easing::InOutSine,
+        )?;
+        animator.animate_corner_radius(
+            widget_id,
+            low_radius,
+            high_radius,
+            duration_ms,
+            Easing::InOutSine,
+        )?;
+        Ok(())
+    }
+
+    pub fn style_accent_cycle<const TRACKS: usize, const BINDINGS: usize>(
+        animator: &mut WidgetAnimator<TRACKS, BINDINGS>,
+        widget_id: WidgetId,
+        from: Rgb565,
+        to: Rgb565,
+        duration_ms: u32,
+    ) -> Result<(), WidgetAnimationError> {
+        animator.animate_accent_color(widget_id, from, to, duration_ms, Easing::InOutSine)?;
+        Ok(())
+    }
+
+    pub fn path_float_loop<const TRACKS: usize, const BINDINGS: usize>(
+        animator: &mut WidgetAnimator<TRACKS, BINDINGS>,
+        widget_id: WidgetId,
+        center_x: i32,
+        center_y: i32,
+        radius: i32,
+        duration_ms: u32,
+    ) -> Result<(), WidgetAnimationError> {
+        let points = [
+            PathPoint::new(center_x as f32, (center_y - radius) as f32),
+            PathPoint::new((center_x + radius) as f32, center_y as f32),
+            PathPoint::new(center_x as f32, (center_y + radius) as f32),
+            PathPoint::new((center_x - radius) as f32, center_y as f32),
+            PathPoint::new(center_x as f32, (center_y - radius) as f32),
+        ];
+        animator.animate_widget_path(widget_id, &points, duration_ms, Easing::InOutSine)?;
+        Ok(())
+    }
+
+    pub fn orchestrate_stagger_x<const TRACKS: usize, const BINDINGS: usize>(
+        animator: &mut WidgetAnimator<TRACKS, BINDINGS>,
+        widget_ids: &[WidgetId],
+        from: i32,
+        to: i32,
+        duration_ms: u32,
+        stagger_ms: u32,
+    ) -> Result<usize, WidgetAnimationError> {
+        animator.stagger_widget_x(widget_ids, from, to, duration_ms, stagger_ms, Easing::OutSine)
     }
 }

--- a/src/widgets/mod.rs
+++ b/src/widgets/mod.rs
@@ -113,6 +113,7 @@ pub enum WidgetKind<'a> {
     Dropdown {
         items: &'a [&'a str],
         selected: usize,
+        open: bool,
     },
     Roller {
         items: &'a [&'a str],
@@ -394,8 +395,12 @@ impl<'a> WidgetNode<'a> {
                 )
             }
             WidgetKind::Spinner { phase } => render_spinner(ctx, rect, phase, self.style, state),
-            WidgetKind::Dropdown { items, selected } => {
-                render_dropdown(ctx, rect, items, selected, self.style, state)
+            WidgetKind::Dropdown {
+                items,
+                selected,
+                open,
+            } => {
+                render_dropdown(ctx, rect, items, selected, open, self.style, state)
             }
             WidgetKind::Roller { items, selected } => {
                 render_roller(ctx, rect, items, selected, self.style, state)
@@ -1273,6 +1278,7 @@ fn render_dropdown<D>(
     rect: Rect,
     items: &[&str],
     selected: usize,
+    open: bool,
     style: WidgetStyle,
     state: VisualState,
 ) -> Result<(), D::Error>
@@ -1283,7 +1289,11 @@ where
     let block = Block::styled(style);
     block.render(rect, ctx)?;
     let inner = block.inner(rect);
-    let text = items.get(selected).copied().unwrap_or("-");
+    let text = if open {
+        items.get(selected).copied().unwrap_or("-")
+    } else {
+        items.get(selected).copied().unwrap_or("-")
+    };
     ctx.draw_text_in(
         Rect::new(inner.x, inner.y, inner.w.saturating_sub(8), inner.h),
         text,
@@ -1291,9 +1301,35 @@ where
     )?;
     ctx.draw_text_in(
         Rect::new(inner.right() - 7, inner.y, 7, inner.h),
-        "v",
+        if open { "^" } else { "v" },
         TextStyle::new(style.accent).with_font(style.font).centered(),
-    )
+    )?;
+    if open {
+        let row_h = style.font.line_height().max(6);
+        let popup_h = (row_h.saturating_mul(items.len() as u32)).min(40).max(row_h);
+        let popup = Rect::new(inner.x, inner.bottom() as i32 + 1, inner.w, popup_h);
+        ctx.fill_rect(popup, style.background.unwrap_or(Rgb565::new(8, 12, 16)))?;
+        ctx.stroke_rect(popup, Border::one(style.border.color))?;
+        let visible = (popup_h / row_h).max(1) as usize;
+        let start = selected.saturating_sub(visible / 2).min(items.len().saturating_sub(visible));
+        for (i, item) in items.iter().enumerate().skip(start).take(visible) {
+            let row = Rect::new(
+                popup.x + 1,
+                popup.y + ((i - start) as u32 * row_h) as i32,
+                popup.w.saturating_sub(2),
+                row_h,
+            );
+            if i == selected {
+                ctx.fill_rect(row, style.accent)?;
+            }
+            ctx.draw_text_in(
+                row.inset(EdgeInsets::all(1)),
+                item,
+                TextStyle::new(style.text).with_font(style.font),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 fn render_roller<D>(

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -1020,6 +1020,149 @@ fn widget_animator_policy_aware_builders_apply_conflict_rules() {
 }
 
 #[test]
+fn widget_animator_extended_property_builders_work() {
+    static TABS: [&str; 3] = ["A", "B", "C"];
+    static ITEMS: [&str; 4] = ["ONE", "TWO", "THREE", "FOUR"];
+    let mut gui = GuiContext::<20, 20, 20>::new(Rect::new(0, 0, 140, 80));
+    let tabs = gui
+        .add_tabs(Rect::new(0, 0, 60, 12), &TABS, 0, Style::button())
+        .unwrap();
+    let dropdown = gui
+        .add_dropdown(Rect::new(62, 0, 56, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    let roller = gui
+        .add_roller(Rect::new(0, 14, 40, 24), &ITEMS, 0, Style::button())
+        .unwrap();
+    let gauge = gui
+        .add_gauge(Rect::new(42, 14, 24, 24), 0.0, 0.0, 1.0, Style::progress())
+        .unwrap();
+    let spinner = gui
+        .add_spinner(Rect::new(68, 14, 16, 16), 0.0, Style::progress())
+        .unwrap();
+    let progress = gui
+        .add_progress_bar(Rect::new(0, 42, 84, 8), 0.0, Style::progress())
+        .unwrap();
+    let card = gui
+        .add_panel(Rect::new(86, 14, 30, 20), Style::panel())
+        .unwrap();
+
+    let mut animator = WidgetAnimator::<24, 24>::new();
+    animator
+        .animate_tab_selected(tabs, 0, 2, 40, Easing::Linear)
+        .unwrap();
+    animator
+        .animate_dropdown_selected(dropdown, 0, 3, 40, Easing::Linear)
+        .unwrap();
+    animator
+        .animate_roller_selected(roller, 0, 2, 40, Easing::Linear)
+        .unwrap();
+    animator
+        .animate_gauge_value(gauge, 0.0, 1.0, 40, Easing::Linear)
+        .unwrap();
+    animator
+        .animate_spinner_phase(spinner, 0.0, 1.0, 40, Easing::Linear)
+        .unwrap();
+    animator
+        .ping_pong_progress(progress, 0.0, 1.0, 20, Easing::InOutSine)
+        .unwrap();
+    animator
+        .pulse_opacity(card, 32, 200, 20, Easing::InOutSine)
+        .unwrap();
+
+    animator.tick(20, &mut gui).unwrap();
+    assert_eq!(gui.tab_selected(tabs), Some(1));
+    assert!(gui.dropdown_selected(dropdown).is_some());
+    assert!(gui.roller_selected(roller).is_some());
+
+    animator.tick(20, &mut gui).unwrap();
+    assert_eq!(gui.tab_selected(tabs), Some(2));
+    assert_eq!(gui.dropdown_selected(dropdown), Some(3));
+    assert_eq!(gui.roller_selected(roller), Some(2));
+}
+
+#[test]
+fn widget_animator_stagger_path_and_presets_work() {
+    let mut gui = GuiContext::<16, 32, 16>::new(Rect::new(0, 0, 120, 80));
+    let a = gui.add_panel(Rect::new(0, 0, 16, 10), Style::panel()).unwrap();
+    let b = gui.add_panel(Rect::new(0, 12, 16, 10), Style::panel()).unwrap();
+    let c = gui.add_panel(Rect::new(0, 24, 16, 10), Style::panel()).unwrap();
+    let focus = gui.add_panel(Rect::new(10, 40, 20, 12), Style::panel()).unwrap();
+
+    let mut animator = WidgetAnimator::<32, 32>::new();
+    assert_eq!(
+        animator
+            .stagger_widget_x(&[a, b, c], 0, 20, 30, 10, Easing::Linear)
+            .unwrap(),
+        3
+    );
+
+    let path = [
+        PathPoint::new(10.0, 40.0),
+        PathPoint::new(20.0, 46.0),
+        PathPoint::new(34.0, 42.0),
+    ];
+    animator
+        .animate_widget_path(focus, &path, 60, Easing::InOutSine)
+        .unwrap();
+    animator.preset_fade_in_up(focus, 46, 40, 40).unwrap();
+    animator.preset_attention_shake(focus, 34, 2, 40).unwrap();
+    animator
+        .animate_corner_radius(focus, 0, 4, 40, Easing::Linear)
+        .unwrap();
+    animator
+        .animate_accent_color(
+            focus,
+            Rgb565::new(0, 20, 10),
+            Rgb565::new(20, 55, 5),
+            40,
+            Easing::Linear,
+        )
+        .unwrap();
+
+    animator.tick(10, &mut gui).unwrap();
+    assert_eq!(gui.absolute_rect(a).unwrap().x, 7);
+    assert_eq!(gui.absolute_rect(b).unwrap().x, 0);
+    animator.tick(10, &mut gui).unwrap();
+    assert!(gui.absolute_rect(b).unwrap().x > 0);
+    animator.tick(40, &mut gui).unwrap();
+    let focus_node = gui.widgets().iter().find(|w| w.id == focus).unwrap();
+    assert!(focus_node.style.normal.corner_radius >= 3);
+}
+
+#[test]
+fn animation_presets_namespace_helpers_work() {
+    let mut gui = GuiContext::<16, 32, 16>::new(Rect::new(0, 0, 120, 80));
+    let a = gui.add_panel(Rect::new(4, 4, 18, 10), Style::panel()).unwrap();
+    let b = gui.add_panel(Rect::new(4, 18, 18, 10), Style::panel()).unwrap();
+    let c = gui.add_panel(Rect::new(4, 32, 18, 10), Style::panel()).unwrap();
+    let focus = gui.add_panel(Rect::new(40, 20, 22, 12), Style::panel()).unwrap();
+
+    let mut animator = WidgetAnimator::<32, 32>::new();
+    assert_eq!(
+        presets::orchestrate_stagger_x(&mut animator, &[a, b, c], 4, 24, 40, 10).unwrap(),
+        3
+    );
+    presets::entrance_fade_in_up(&mut animator, focus, 30, 20, 40).unwrap();
+    presets::attention_shake(&mut animator, focus, 40, 2, 40).unwrap();
+    presets::style_breathe(&mut animator, focus, 96, 200, 0, 4, 40).unwrap();
+    presets::style_accent_cycle(
+        &mut animator,
+        focus,
+        Rgb565::new(0, 20, 10),
+        Rgb565::new(20, 55, 5),
+        40,
+    )
+    .unwrap();
+    presets::path_float_loop(&mut animator, focus, 40, 20, 2, 40).unwrap();
+
+    animator.tick(10, &mut gui).unwrap();
+    assert!(gui.absolute_rect(a).unwrap().x > 4);
+    animator.tick(40, &mut gui).unwrap();
+    let node = gui.widgets().iter().find(|w| w.id == focus).unwrap();
+    assert!(node.style.normal.corner_radius >= 3);
+}
+
+#[test]
 fn animation_edge_cases_cover_delay_reverse_and_id_wrap() {
     let mut anim = Animation::new(0.0, 1.0, 0, Easing::Linear)
         .with_delay(20)
@@ -1481,7 +1624,7 @@ fn style_transition_interpolates_between_states() {
 fn new_widgets_chart_spinner_dropdown_render_and_update() {
     static SERIES: [f32; 5] = [0.0, 0.5, 0.2, 0.8, 0.6];
     static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
-    let mut gui = GuiContext::<16, 16, 16>::new(Rect::new(0, 0, 96, 48));
+    let mut gui = GuiContext::<16, 32, 16>::new(Rect::new(0, 0, 96, 48));
     let chart = gui
         .add_chart(Rect::new(0, 0, 32, 16), &SERIES, 0.0, 1.0, Style::panel())
         .unwrap();
@@ -1498,8 +1641,12 @@ fn new_widgets_chart_spinner_dropdown_render_and_update() {
     gui.set_dropdown_selected(dropdown, 2).unwrap();
     assert_eq!(gui.dropdown_selected(dropdown), Some(2));
     gui.set_focus(Some(dropdown)).unwrap();
+    gui.handle_input(InputEvent::Select).unwrap();
+    assert_eq!(gui.dropdown_open(dropdown), Some(true));
     gui.handle_input(InputEvent::Down).unwrap();
     assert_eq!(gui.dropdown_selected(dropdown), Some(0));
+    gui.handle_input(InputEvent::Select).unwrap();
+    assert_eq!(gui.dropdown_open(dropdown), Some(false));
     let roller = gui
         .add_roller(Rect::new(0, 18, 30, 20), &ITEMS, 0, Style::button())
         .unwrap();
@@ -1725,7 +1872,7 @@ fn render_digest_stays_stable() {
             ^ ((c.b() as u64) << 48)
     });
 
-    assert_eq!(digest, 4_248_994_834_688_788_393);
+    assert_eq!(digest, 15_293_939_628_664_047_529);
 }
 
 #[test]
@@ -2123,6 +2270,215 @@ fn pointer_release_cancels_pending_long_press() {
 
     gui.tick_input(40).unwrap();
     assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn dropdown_emits_open_close_events() {
+    static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 64, 32));
+    let dropdown = gui
+        .add_dropdown(Rect::new(0, 0, 40, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    gui.set_focus(Some(dropdown)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Select).unwrap();
+    let mut saw_opened = false;
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::Opened(dropdown) {
+            saw_opened = true;
+            break;
+        }
+    }
+    assert!(saw_opened);
+    assert_eq!(gui.dropdown_open(dropdown), Some(true));
+
+    gui.handle_input(InputEvent::Select).unwrap();
+    let mut saw_closed = false;
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::Closed(dropdown) {
+            saw_closed = true;
+            break;
+        }
+    }
+    assert!(saw_closed);
+    assert_eq!(gui.dropdown_open(dropdown), Some(false));
+}
+
+#[test]
+fn textarea_edit_hooks_emit_text_input_events() {
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 64, 32));
+    let textarea = gui
+        .add_textarea(Rect::new(0, 0, 50, 14), "HELLO", "TYPE", Style::panel())
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.textarea_insert_char(textarea, 'x').unwrap();
+    gui.textarea_backspace(textarea).unwrap();
+    gui.textarea_delete_forward(textarea).unwrap();
+
+    assert_eq!(gui.pop_event(), Some(UiEvent::TextInput { id: textarea, ch: 'x' }));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(textarea)));
+    assert_eq!(
+        gui.pop_event(),
+        Some(UiEvent::TextInput {
+            id: textarea,
+            ch: '\u{8}'
+        })
+    );
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(textarea)));
+    assert_eq!(
+        gui.pop_event(),
+        Some(UiEvent::TextInput {
+            id: textarea,
+            ch: '\u{7f}'
+        })
+    );
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(textarea)));
+}
+
+#[test]
+fn pointer_move_emits_gesture_once_after_threshold() {
+    let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 4,
+        y: 4,
+        state: PointerState::Moved,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    assert_eq!(gui.pop_event(), None);
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 10,
+        y: 4,
+        state: PointerState::Moved,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::Gesture(button)));
+    assert_eq!(gui.pop_event(), None);
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 14,
+        y: 4,
+        state: PointerState::Moved,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn scrollable_drag_emits_scroll_event() {
+    let mut gui = GuiContext::<8, 24, 8>::new(Rect::new(0, 0, 64, 32));
+    let scroll = gui
+        .add_scroll_view(Rect::new(0, 0, 30, 20), 0, 80, Style::panel())
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 8,
+        state: PointerState::Moved,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+
+    let mut saw_scroll = false;
+    while let Some(event) = gui.pop_event() {
+        if matches!(event, UiEvent::Scroll { id, delta } if id == scroll && delta != 0) {
+            saw_scroll = true;
+            break;
+        }
+    }
+    assert!(saw_scroll);
+}
+
+#[test]
+fn long_press_repeat_emits_repeated_activate_for_button() {
+    let mut gui = GuiContext::<4, 32, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_long_press_threshold_ms(10);
+    gui.set_press_repeat_timing(20, 10);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.tick_input(10).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::LongPressed(button)));
+    assert_eq!(gui.pop_event(), None);
+
+    gui.tick_input(20).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::Clicked(button)));
+    assert_eq!(gui.pop_event(), Some(UiEvent::Activate(button)));
+}
+
+#[test]
+fn drag_release_continues_scroll_with_inertia() {
+    let mut gui = GuiContext::<8, 48, 8>::new(Rect::new(0, 0, 64, 32));
+    let scroll = gui
+        .add_scroll_view(Rect::new(0, 0, 30, 20), 0, 120, Style::panel())
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 14,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Moved,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    let before_release = gui.scroll_offset(scroll).unwrap_or(0);
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.tick_input(16).unwrap();
+    let after_tick = gui.scroll_offset(scroll).unwrap_or(0);
+    assert_ne!(after_tick, before_release);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Extend input semantics with pointer gesture dispatch, drag scrolling inertia, press-repeat activation, and dropdown open/close events.
- Expand widget animation support with many new animatable properties plus preset helpers for entrance, attention, style, path, and staggered orchestration.
- Add focused coverage and demos, including `animation_kitchen_sink_showcase`, `input_gesture_drag_repeat_showcase`, and a docs cheat-sheet with one-liner preset snippets.

## Test plan
- [x] `cargo test --test gui`
- [x] `cargo check --example animation_kitchen_sink_showcase`
- [x] `cargo check --example input_gesture_drag_repeat_showcase`