### PR TITLE
Add scroll physics controls and opt-in focus state transitions

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -84,6 +84,14 @@ struct TextareaHistoryEntry {
     snapshot: TextareaSnapshot,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+struct StateTransition {
+    id: WidgetId,
+    from: VisualState,
+    to: VisualState,
+    elapsed_ms: u32,
+}
+
 pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize> {
     viewport: Rect,
     widgets: Vec<WidgetNode<'a>, NODES>,
@@ -104,6 +112,8 @@ pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: 
     pressed: Option<PressTracker>,
     inertia_scroll: Option<InertiaScroll>,
     scroll_physics: ScrollPhysics,
+    state_transition_ms: u32,
+    state_transitions: Vec<StateTransition, NODES>,
     textarea_undo: Vec<TextareaHistoryEntry, NODES>,
     textarea_redo: Vec<TextareaHistoryEntry, NODES>,
     next_id: u16,
@@ -135,6 +145,8 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             pressed: None,
             inertia_scroll: None,
             scroll_physics: ScrollPhysics::default(),
+            state_transition_ms: 0,
+            state_transitions: Vec::new(),
             textarea_undo: Vec::new(),
             textarea_redo: Vec::new(),
             next_id: 1,
@@ -159,6 +171,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.focus = None;
         self.pressed = None;
         self.inertia_scroll = None;
+        self.state_transitions.clear();
         self.textarea_undo.clear();
         self.textarea_redo.clear();
         self.dirty.mark_all(self.viewport)?;
@@ -187,6 +200,17 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.scroll_physics.velocity_threshold = velocity_threshold.max(0.001);
         self.scroll_physics.velocity_decay = velocity_decay.clamp(0.01, 0.999);
         self.scroll_physics.drag_velocity_blend = drag_velocity_blend.clamp(0.01, 1.0);
+    }
+
+    pub fn set_state_transition_duration_ms(&mut self, duration_ms: u32) {
+        self.state_transition_ms = duration_ms;
+        if duration_ms == 0 {
+            self.state_transitions.clear();
+        }
+    }
+
+    pub fn active_state_transitions(&self) -> usize {
+        self.state_transitions.len()
     }
 
     pub fn set_textarea_cursor_blink_timing(&mut self, period_ms: u32) {
@@ -328,6 +352,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.textarea_cursor_blink_elapsed_ms = 0;
         self.set_textarea_cursor_visible(old, true);
         self.set_textarea_cursor_visible(focus, true);
+        self.start_focus_transitions(old, focus);
         self.mark_focus_pair(old, focus)?;
         if let Some(id) = old {
             self.push_event(UiEvent::Defocused(id))?;
@@ -2616,6 +2641,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     }
 
     pub fn tick_input(&mut self, dt_ms: u32) -> Result<(), GuiError> {
+        self.tick_state_transitions(dt_ms)?;
         if let Some(mut inertia) = self.inertia_scroll {
             if inertia.velocity.abs() < self.scroll_physics.velocity_threshold {
                 self.inertia_scroll = None;
@@ -2826,6 +2852,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                     let class_state = style.resolve(state);
                     render_node.style = node.style.with_state_override(state, class_state);
                 }
+            }
+            if let Some((from, to, t)) = self.state_transition_progress(node.id) {
+                let blended = lerp_style(render_node.style.resolve(from), render_node.style.resolve(to), t);
+                render_node.style = render_node.style.with_state_override(state, blended);
             }
             if opacity < 255 {
                 let apply = |v: u8| -> u8 { ((v as u16 * opacity as u16) / 255) as u8 };
@@ -3485,6 +3515,81 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             }
         }
         Ok(())
+    }
+
+    fn start_focus_transitions(&mut self, old: Option<WidgetId>, new: Option<WidgetId>) {
+        if self.state_transition_ms == 0 {
+            return;
+        }
+        if let Some(id) = old {
+            self.start_state_transition(id, VisualState::Focused, VisualState::Normal);
+        }
+        if let Some(id) = new {
+            self.start_state_transition(id, VisualState::Normal, VisualState::Focused);
+        }
+    }
+
+    fn start_state_transition(&mut self, id: WidgetId, from: VisualState, to: VisualState) {
+        if self.state_transition_ms == 0 || from == to {
+            return;
+        }
+        if let Some(entry) = self.state_transitions.iter_mut().find(|entry| entry.id == id) {
+            *entry = StateTransition {
+                id,
+                from,
+                to,
+                elapsed_ms: 0,
+            };
+            return;
+        }
+        if self.state_transitions.len() == self.state_transitions.capacity() {
+            self.state_transitions.remove(0);
+        }
+        let _ = self.state_transitions.push(StateTransition {
+            id,
+            from,
+            to,
+            elapsed_ms: 0,
+        });
+    }
+
+    fn tick_state_transitions(&mut self, dt_ms: u32) -> Result<(), GuiError> {
+        if self.state_transitions.is_empty() || self.state_transition_ms == 0 {
+            return Ok(());
+        }
+        let mut i = 0usize;
+        while i < self.state_transitions.len() {
+            let mut remove = false;
+            let id;
+            {
+                let entry = &mut self.state_transitions[i];
+                entry.elapsed_ms = entry.elapsed_ms.saturating_add(dt_ms);
+                if entry.elapsed_ms >= self.state_transition_ms {
+                    remove = true;
+                }
+                id = entry.id;
+            }
+            if let Some(rect) = self.absolute_rect(id) {
+                self.dirty.add(rect)?;
+            }
+            if remove {
+                self.state_transitions.remove(i);
+            } else {
+                i += 1;
+            }
+        }
+        Ok(())
+    }
+
+    fn state_transition_progress(&self, id: WidgetId) -> Option<(VisualState, VisualState, f32)> {
+        let duration = self.state_transition_ms.max(1);
+        self.state_transitions
+            .iter()
+            .find(|entry| entry.id == id)
+            .map(|entry| {
+                let t = (entry.elapsed_ms as f32 / duration as f32).clamp(0.0, 1.0);
+                (entry.from, entry.to, t)
+            })
     }
 
     fn set_textarea_cursor_visible(&mut self, id: Option<WidgetId>, visible: bool) {

--- a/src/context.rs
+++ b/src/context.rs
@@ -53,6 +53,23 @@ struct InertiaScroll {
     velocity: f32,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct ScrollPhysics {
+    pub velocity_threshold: f32,
+    pub velocity_decay: f32,
+    pub drag_velocity_blend: f32,
+}
+
+impl Default for ScrollPhysics {
+    fn default() -> Self {
+        Self {
+            velocity_threshold: 0.05,
+            velocity_decay: 0.86,
+            drag_velocity_blend: 0.4,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct TextareaSnapshot {
     text_buf: [u8; TEXTAREA_CAPACITY],
@@ -86,6 +103,7 @@ pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: 
     press_repeat_interval_ms: u32,
     pressed: Option<PressTracker>,
     inertia_scroll: Option<InertiaScroll>,
+    scroll_physics: ScrollPhysics,
     textarea_undo: Vec<TextareaHistoryEntry, NODES>,
     textarea_redo: Vec<TextareaHistoryEntry, NODES>,
     next_id: u16,
@@ -116,6 +134,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             press_repeat_interval_ms: 140,
             pressed: None,
             inertia_scroll: None,
+            scroll_physics: ScrollPhysics::default(),
             textarea_undo: Vec::new(),
             textarea_redo: Vec::new(),
             next_id: 1,
@@ -157,6 +176,17 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     pub fn set_press_repeat_timing(&mut self, delay_ms: u32, interval_ms: u32) {
         self.press_repeat_delay_ms = delay_ms.max(1);
         self.press_repeat_interval_ms = interval_ms.max(1);
+    }
+
+    pub fn set_scroll_physics(
+        &mut self,
+        velocity_threshold: f32,
+        velocity_decay: f32,
+        drag_velocity_blend: f32,
+    ) {
+        self.scroll_physics.velocity_threshold = velocity_threshold.max(0.001);
+        self.scroll_physics.velocity_decay = velocity_decay.clamp(0.01, 0.999);
+        self.scroll_physics.drag_velocity_blend = drag_velocity_blend.clamp(0.01, 1.0);
     }
 
     pub fn set_textarea_cursor_blink_timing(&mut self, period_ms: u32) {
@@ -2587,7 +2617,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
 
     pub fn tick_input(&mut self, dt_ms: u32) -> Result<(), GuiError> {
         if let Some(mut inertia) = self.inertia_scroll {
-            if inertia.velocity.abs() < 0.05 {
+            if inertia.velocity.abs() < self.scroll_physics.velocity_threshold {
                 self.inertia_scroll = None;
             } else {
                 let current = self.scroll_offset(inertia.id).unwrap_or(0);
@@ -2602,7 +2632,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                         })?;
                     }
                 }
-                inertia.velocity *= 0.86f32.powf((dt_ms as f32 / 16.0).max(1.0));
+                inertia.velocity *=
+                    self.scroll_physics
+                        .velocity_decay
+                        .powf((dt_ms as f32 / 16.0).max(1.0));
                 self.inertia_scroll = Some(inertia);
             }
         }
@@ -3301,7 +3334,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     fn handle_pointer_released(&mut self, x: i32, y: i32) -> Result<(), GuiError> {
         if let Some(pressed) = self.pressed {
             if let Some(scroll_id) = self.scrollable_ancestor(pressed.id) {
-                if pressed.scroll_velocity.abs() > 0.2 {
+                if pressed.scroll_velocity.abs() > self.scroll_physics.velocity_threshold {
                     self.inertia_scroll = Some(InertiaScroll {
                         id: scroll_id,
                         velocity: pressed.scroll_velocity,
@@ -3360,7 +3393,8 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                     |_| EventPolicy::Continue,
                 )?;
             }
-            pressed.scroll_velocity = pressed.scroll_velocity * 0.6 + (dy as f32) * 0.4;
+            let blend = self.scroll_physics.drag_velocity_blend;
+            pressed.scroll_velocity = pressed.scroll_velocity * (1.0 - blend) + (dy as f32) * blend;
         }
         self.pressed = Some(pressed);
         Ok(())

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -2720,6 +2720,89 @@ fn drag_release_continues_scroll_with_inertia() {
 }
 
 #[test]
+fn scroll_physics_threshold_controls_inertia_start() {
+    let mut gui = GuiContext::<8, 48, 8>::new(Rect::new(0, 0, 64, 32));
+    let scroll = gui
+        .add_scroll_view(Rect::new(0, 0, 30, 20), 0, 120, Style::panel())
+        .unwrap();
+    gui.set_scroll_physics(100.0, 0.86, 0.4);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 14,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Moved,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    let before_release = gui.scroll_offset(scroll).unwrap_or(0);
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.tick_input(16).unwrap();
+    let after_tick = gui.scroll_offset(scroll).unwrap_or(0);
+    assert_eq!(after_tick, before_release);
+}
+
+#[test]
+fn scroll_physics_decay_controls_inertia_persistence() {
+    let mut gui_fast_decay = GuiContext::<8, 48, 8>::new(Rect::new(0, 0, 64, 32));
+    let mut gui_slow_decay = GuiContext::<8, 48, 8>::new(Rect::new(0, 0, 64, 32));
+    let fast = gui_fast_decay
+        .add_scroll_view(Rect::new(0, 0, 30, 20), 0, 120, Style::panel())
+        .unwrap();
+    let slow = gui_slow_decay
+        .add_scroll_view(Rect::new(0, 0, 30, 20), 0, 120, Style::panel())
+        .unwrap();
+    gui_fast_decay.set_scroll_physics(0.01, 0.15, 0.5);
+    gui_slow_decay.set_scroll_physics(0.01, 0.98, 0.5);
+
+    for (gui, id) in [(&mut gui_fast_decay, fast), (&mut gui_slow_decay, slow)] {
+        gui.handle_input(InputEvent::Pointer {
+            x: 2,
+            y: 14,
+            state: PointerState::Pressed,
+            button: PointerButton::Primary,
+        })
+        .unwrap();
+        gui.handle_input(InputEvent::Pointer {
+            x: 2,
+            y: 2,
+            state: PointerState::Moved,
+            button: PointerButton::Primary,
+        })
+        .unwrap();
+        gui.handle_input(InputEvent::Pointer {
+            x: 2,
+            y: 2,
+            state: PointerState::Released,
+            button: PointerButton::Primary,
+        })
+        .unwrap();
+        let _ = id;
+    }
+
+    for _ in 0..5 {
+        gui_fast_decay.tick_input(16).unwrap();
+        gui_slow_decay.tick_input(16).unwrap();
+    }
+    let fast_offset = gui_fast_decay.scroll_offset(fast).unwrap_or(0);
+    let slow_offset = gui_slow_decay.scroll_offset(slow).unwrap_or(0);
+    assert!(slow_offset.abs() > fast_offset.abs());
+}
+
+#[test]
 fn event_filter_limits_targeted_app_events() {
     let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
     let button = gui

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -2803,6 +2803,42 @@ fn scroll_physics_decay_controls_inertia_persistence() {
 }
 
 #[test]
+fn focus_state_transitions_progress_and_complete() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let first = gui
+        .add_button(Rect::new(0, 0, 20, 10), "A", Style::button())
+        .unwrap();
+    let second = gui
+        .add_button(Rect::new(0, 12, 20, 10), "B", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(30);
+    gui.set_focus(Some(first)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.set_focus(Some(second)).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+    gui.tick_input(10).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+    gui.tick_input(40).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
+fn zero_duration_disables_state_transition_queue() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let first = gui
+        .add_button(Rect::new(0, 0, 20, 10), "A", Style::button())
+        .unwrap();
+    let second = gui
+        .add_button(Rect::new(0, 12, 20, 10), "B", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(0);
+    gui.set_focus(Some(first)).unwrap();
+    gui.set_focus(Some(second)).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
 fn event_filter_limits_targeted_app_events() {
     let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
     let button = gui


### PR DESCRIPTION
## Summary
- Add configurable scroll physics in `GuiContext` (velocity threshold, decay, drag velocity blend) and wire it into drag + inertia behavior.
- Add opt-in focus state transitions with fixed-capacity runtime tracking and per-frame style interpolation during render.
- Add regression tests for inertia threshold/decay tuning and focus transition progression/disable behavior.

## Test plan
- [x] `cargo test --test gui`
- [x] `cargo check`