### PR TITLE
Expand input recognizers and key policy controls

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -71,6 +71,52 @@ impl Default for ScrollPhysics {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct PressTiming {
+    pub long_press_ms: u32,
+    pub repeat_delay_ms: u32,
+    pub repeat_interval_ms: u32,
+}
+
+impl PressTiming {
+    pub const fn new(long_press_ms: u32, repeat_delay_ms: u32, repeat_interval_ms: u32) -> Self {
+        Self {
+            long_press_ms,
+            repeat_delay_ms,
+            repeat_interval_ms,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct WidgetKeyInputPolicy {
+    pub raw_select: bool,
+    pub raw_back: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum KeyBindingAction {
+    Default,
+    Ignore,
+    Activate,
+    Back,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct WidgetKeyBindings {
+    pub select: KeyBindingAction,
+    pub back: KeyBindingAction,
+}
+
+impl Default for WidgetKeyBindings {
+    fn default() -> Self {
+        Self {
+            select: KeyBindingAction::Default,
+            back: KeyBindingAction::Default,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 struct TextareaSnapshot {
     text_buf: [u8; TEXTAREA_CAPACITY],
     text_len: u8,
@@ -109,11 +155,20 @@ pub struct GuiContext<'a, const NODES: usize, const EVENTS: usize, const DIRTY: 
     textarea_cursor_blink_elapsed_ms: u32,
     press_repeat_delay_ms: u32,
     press_repeat_interval_ms: u32,
+    select_double_window_ms: u32,
+    select_elapsed_ms: u32,
+    last_select_id: Option<WidgetId>,
+    pointer_double_window_ms: u32,
+    pointer_elapsed_ms: u32,
+    last_pointer_id: Option<WidgetId>,
     pressed: Option<PressTracker>,
     inertia_scroll: Option<InertiaScroll>,
     scroll_physics: ScrollPhysics,
     state_transition_ms: u32,
     state_transitions: Vec<StateTransition, NODES>,
+    widget_press_timings: Vec<(WidgetId, PressTiming), NODES>,
+    widget_key_policies: Vec<(WidgetId, WidgetKeyInputPolicy), NODES>,
+    widget_key_bindings: Vec<(WidgetId, WidgetKeyBindings), NODES>,
     textarea_undo: Vec<TextareaHistoryEntry, NODES>,
     textarea_redo: Vec<TextareaHistoryEntry, NODES>,
     next_id: u16,
@@ -142,11 +197,20 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             textarea_cursor_blink_elapsed_ms: 0,
             press_repeat_delay_ms: 650,
             press_repeat_interval_ms: 140,
+            select_double_window_ms: 300,
+            select_elapsed_ms: 0,
+            last_select_id: None,
+            pointer_double_window_ms: 300,
+            pointer_elapsed_ms: 0,
+            last_pointer_id: None,
             pressed: None,
             inertia_scroll: None,
             scroll_physics: ScrollPhysics::default(),
             state_transition_ms: 0,
             state_transitions: Vec::new(),
+            widget_press_timings: Vec::new(),
+            widget_key_policies: Vec::new(),
+            widget_key_bindings: Vec::new(),
             textarea_undo: Vec::new(),
             textarea_redo: Vec::new(),
             next_id: 1,
@@ -171,7 +235,14 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         self.focus = None;
         self.pressed = None;
         self.inertia_scroll = None;
+        self.last_select_id = None;
+        self.select_elapsed_ms = 0;
+        self.last_pointer_id = None;
+        self.pointer_elapsed_ms = 0;
         self.state_transitions.clear();
+        self.widget_press_timings.clear();
+        self.widget_key_policies.clear();
+        self.widget_key_bindings.clear();
         self.textarea_undo.clear();
         self.textarea_redo.clear();
         self.dirty.mark_all(self.viewport)?;
@@ -189,6 +260,142 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     pub fn set_press_repeat_timing(&mut self, delay_ms: u32, interval_ms: u32) {
         self.press_repeat_delay_ms = delay_ms.max(1);
         self.press_repeat_interval_ms = interval_ms.max(1);
+    }
+
+    pub fn set_double_select_window_ms(&mut self, window_ms: u32) {
+        self.select_double_window_ms = window_ms.max(1);
+    }
+
+    pub fn set_double_pointer_window_ms(&mut self, window_ms: u32) {
+        self.pointer_double_window_ms = window_ms.max(1);
+    }
+
+    pub fn set_widget_press_timing(
+        &mut self,
+        id: WidgetId,
+        timing: PressTiming,
+    ) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        let timing = PressTiming {
+            long_press_ms: timing.long_press_ms.max(1),
+            repeat_delay_ms: timing.repeat_delay_ms.max(1),
+            repeat_interval_ms: timing.repeat_interval_ms.max(1),
+        };
+        if let Some((_, current)) = self
+            .widget_press_timings
+            .iter_mut()
+            .find(|(timing_id, _)| *timing_id == id)
+        {
+            *current = timing;
+            return Ok(());
+        }
+        self.widget_press_timings
+            .push((id, timing))
+            .map_err(|_| GuiError::WidgetsFull)
+    }
+
+    pub fn clear_widget_press_timing(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        if let Some(pos) = self
+            .widget_press_timings
+            .iter()
+            .position(|(timing_id, _)| *timing_id == id)
+        {
+            self.widget_press_timings.remove(pos);
+        }
+        Ok(())
+    }
+
+    pub fn widget_press_timing(&self, id: WidgetId) -> Result<Option<PressTiming>, GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        Ok(self
+            .widget_press_timings
+            .iter()
+            .find(|(timing_id, _)| *timing_id == id)
+            .map(|(_, timing)| *timing))
+    }
+
+    pub fn set_widget_key_input_policy(
+        &mut self,
+        id: WidgetId,
+        policy: WidgetKeyInputPolicy,
+    ) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        if let Some((_, current)) = self
+            .widget_key_policies
+            .iter_mut()
+            .find(|(policy_id, _)| *policy_id == id)
+        {
+            *current = policy;
+            return Ok(());
+        }
+        self.widget_key_policies
+            .push((id, policy))
+            .map_err(|_| GuiError::WidgetsFull)
+    }
+
+    pub fn clear_widget_key_input_policy(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        if let Some(pos) = self
+            .widget_key_policies
+            .iter()
+            .position(|(policy_id, _)| *policy_id == id)
+        {
+            self.widget_key_policies.remove(pos);
+        }
+        Ok(())
+    }
+
+    pub fn widget_key_input_policy(
+        &self,
+        id: WidgetId,
+    ) -> Result<Option<WidgetKeyInputPolicy>, GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        Ok(self
+            .widget_key_policies
+            .iter()
+            .find(|(policy_id, _)| *policy_id == id)
+            .map(|(_, policy)| *policy))
+    }
+
+    pub fn set_widget_key_bindings(
+        &mut self,
+        id: WidgetId,
+        bindings: WidgetKeyBindings,
+    ) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        if let Some((_, current)) = self
+            .widget_key_bindings
+            .iter_mut()
+            .find(|(binding_id, _)| *binding_id == id)
+        {
+            *current = bindings;
+            return Ok(());
+        }
+        self.widget_key_bindings
+            .push((id, bindings))
+            .map_err(|_| GuiError::WidgetsFull)
+    }
+
+    pub fn clear_widget_key_bindings(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        if let Some(pos) = self
+            .widget_key_bindings
+            .iter()
+            .position(|(binding_id, _)| *binding_id == id)
+        {
+            self.widget_key_bindings.remove(pos);
+        }
+        Ok(())
+    }
+
+    pub fn widget_key_bindings(&self, id: WidgetId) -> Result<Option<WidgetKeyBindings>, GuiError> {
+        self.node(id).ok_or(GuiError::NotFound)?;
+        Ok(self
+            .widget_key_bindings
+            .iter()
+            .find(|(binding_id, _)| *binding_id == id)
+            .map(|(_, bindings)| *bindings))
     }
 
     pub fn set_scroll_physics(
@@ -1688,6 +1895,8 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 for c in textarea_text(text_buf, *text_len).chars() {
                     let _ = chars.push(c);
                 }
+                let original_len = chars.len();
+                let original_cursor = *cursor;
 
                 if ch == '\u{8}' {
                     let removed_selection = delete_selection_if_any(&mut chars, cursor, selection);
@@ -1695,7 +1904,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                         chars.remove(*cursor - 1);
                         *cursor -= 1;
                     }
-                    if removed_selection || *cursor < textarea_text(text_buf, *text_len).chars().count() {
+                    if removed_selection || *cursor != original_cursor || chars.len() != original_len {
                         *selection = None;
                         let (next_buf, next_len) = textarea_storage_from_chars(&chars);
                         *text_buf = next_buf;
@@ -1707,8 +1916,7 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                     if !removed_selection && *cursor < chars.len() {
                         chars.remove(*cursor);
                     }
-                    if removed_selection || *cursor < textarea_text(text_buf, *text_len).chars().count()
-                    {
+                    if removed_selection || chars.len() != original_len {
                         *selection = None;
                         let (next_buf, next_len) = textarea_storage_from_chars(&chars);
                         *text_buf = next_buf;
@@ -1737,9 +1945,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             self.push_textarea_undo(id, before);
             self.clear_textarea_redo_for(id);
             self.dirty.add(rect)?;
+            self.push_event(UiEvent::TextInput { id, ch })?;
+            self.push_event(UiEvent::ValueChanged(id))?;
         }
-        self.push_event(UiEvent::TextInput { id, ch })?;
-        self.push_event(UiEvent::ValueChanged(id))
+        Ok(())
     }
 
     fn textarea_line_context(&self, id: WidgetId) -> Result<(&str, usize, usize), GuiError> {
@@ -2121,11 +2330,18 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         flag: WidgetFlags,
         enabled: bool,
     ) -> Result<(), GuiError> {
+        let was_set = self.has_flag(id, flag)?;
+        let before_state = self.current_visual_state(id);
         self.mark_subtree_dirty(id)?;
         self.node_mut(id)
             .ok_or(GuiError::NotFound)?
             .flags
             .set(flag, enabled);
+        if flag == WidgetFlags::DISABLED && enabled {
+            if self.pressed.is_some_and(|pressed| pressed.id == id) {
+                self.pressed = None;
+            }
+        }
         self.mark_subtree_dirty(id)?;
         if self
             .focus
@@ -2133,6 +2349,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         {
             self.focus = None;
             self.ensure_focus();
+        }
+        if flag == WidgetFlags::DISABLED && was_set != enabled {
+            let after_state = self.current_visual_state(id);
+            self.start_state_transition(id, before_state, after_state);
         }
         Ok(())
     }
@@ -2605,18 +2825,60 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             }
             InputEvent::Select => {
                 if let Some(id) = self.focus {
-                    self.dispatch_activation(id, false)?;
+                    match self.key_bindings_for(id).select {
+                        KeyBindingAction::Default | KeyBindingAction::Activate => {
+                            self.handle_select_activation(id)?
+                        }
+                        KeyBindingAction::Back => self.handle_back_action()?,
+                        KeyBindingAction::Ignore => {}
+                    }
+                }
+                Ok(())
+            }
+            InputEvent::SelectPressed => {
+                if let Some(id) = self.focus {
+                    if self.key_input_policy_for(id).raw_select {
+                        self.dispatch_key_pressed(id)?;
+                    }
+                }
+                Ok(())
+            }
+            InputEvent::SelectReleased => {
+                if let Some(id) = self.focus {
+                    if self.key_input_policy_for(id).raw_select {
+                        self.dispatch_key_released(id)?;
+                        self.handle_select_activation(id)?;
+                    }
                 }
                 Ok(())
             }
             InputEvent::Back => {
                 if let Some(id) = self.focus {
-                    if matches!(self.node(id).map(|n| n.kind), Some(WidgetKind::TextArea { .. })) {
-                        self.textarea_backspace(id)?;
-                        return Ok(());
+                    match self.key_bindings_for(id).back {
+                        KeyBindingAction::Default | KeyBindingAction::Back => self.handle_back_action(),
+                        KeyBindingAction::Activate => self.handle_select_activation(id),
+                        KeyBindingAction::Ignore => Ok(()),
+                    }
+                } else {
+                    self.handle_back_action()
+                }
+            }
+            InputEvent::BackPressed => {
+                if let Some(id) = self.focus {
+                    if self.key_input_policy_for(id).raw_back {
+                        self.dispatch_key_pressed(id)?;
                     }
                 }
-                self.push_event(UiEvent::Back)
+                Ok(())
+            }
+            InputEvent::BackReleased => {
+                if let Some(id) = self.focus {
+                    if self.key_input_policy_for(id).raw_back {
+                        self.dispatch_key_released(id)?;
+                        return self.handle_back_action();
+                    }
+                }
+                Ok(())
             }
             InputEvent::Pointer {
                 x,
@@ -2641,6 +2903,20 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
     }
 
     pub fn tick_input(&mut self, dt_ms: u32) -> Result<(), GuiError> {
+        if self.last_select_id.is_some() {
+            self.select_elapsed_ms = self.select_elapsed_ms.saturating_add(dt_ms);
+            if self.select_elapsed_ms > self.select_double_window_ms {
+                self.last_select_id = None;
+                self.select_elapsed_ms = 0;
+            }
+        }
+        if self.last_pointer_id.is_some() {
+            self.pointer_elapsed_ms = self.pointer_elapsed_ms.saturating_add(dt_ms);
+            if self.pointer_elapsed_ms > self.pointer_double_window_ms {
+                self.last_pointer_id = None;
+                self.pointer_elapsed_ms = 0;
+            }
+        }
         self.tick_state_transitions(dt_ms)?;
         if let Some(mut inertia) = self.inertia_scroll {
             if inertia.velocity.abs() < self.scroll_physics.velocity_threshold {
@@ -2673,9 +2949,10 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             self.pressed = None;
             return Ok(());
         }
+        let timing = self.press_timing_for(pressed.id);
         pressed.elapsed_ms = pressed.elapsed_ms.saturating_add(dt_ms);
         pressed.repeat_elapsed_ms = pressed.repeat_elapsed_ms.saturating_add(dt_ms);
-        if !pressed.long_emitted && pressed.elapsed_ms >= self.long_press_ms {
+        if !pressed.long_emitted && pressed.elapsed_ms >= timing.long_press_ms {
             let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
             self.dispatch_widget_event(pressed.id, WidgetEventKind::LongPressed, &mut events, |_| {
                 EventPolicy::Continue
@@ -2683,15 +2960,15 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             self.push_event(UiEvent::LongPressed(pressed.id))?;
             pressed.long_emitted = true;
         }
-        if pressed.repeat_elapsed_ms >= self.press_repeat_delay_ms
+        if pressed.repeat_elapsed_ms >= timing.repeat_delay_ms
             && self.repeatable_widget(pressed.id)
             && pressed.long_emitted
         {
-            let intervals = (pressed.repeat_elapsed_ms - self.press_repeat_delay_ms)
-                / self.press_repeat_interval_ms;
+            let intervals = (pressed.repeat_elapsed_ms - timing.repeat_delay_ms)
+                / timing.repeat_interval_ms;
             if intervals > 0 {
                 self.dispatch_repeat_activation(pressed.id)?;
-                pressed.repeat_elapsed_ms = self.press_repeat_delay_ms;
+                pressed.repeat_elapsed_ms = timing.repeat_delay_ms;
             }
         }
         self.pressed = Some(pressed);
@@ -2839,7 +3116,9 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             }
             let old_clip = ctx.clip();
             ctx.set_clip(old_clip.intersection(clip));
-            let state = if Some(node.id) == self.focus {
+            let state = if self.pressed.is_some_and(|pressed| pressed.id == node.id) {
+                VisualState::Pressed
+            } else if Some(node.id) == self.focus {
                 VisualState::Focused
             } else if !self.effective_enabled(node.id) {
                 VisualState::Disabled
@@ -2847,16 +3126,23 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                 VisualState::Normal
             };
             let mut render_node = *node;
-            if let Some(class) = node.style_class {
-                if let Some((_, style)) = self.class_styles.iter().find(|(id, _)| *id == class) {
-                    let class_state = style.resolve(state);
-                    render_node.style = node.style.with_state_override(state, class_state);
-                }
-            }
-            if let Some((from, to, t)) = self.state_transition_progress(node.id) {
-                let blended = lerp_style(render_node.style.resolve(from), render_node.style.resolve(to), t);
-                render_node.style = render_node.style.with_state_override(state, blended);
-            }
+            let class_style = node.style_class.and_then(|class| {
+                self.class_styles
+                    .iter()
+                    .find(|(id, _)| *id == class)
+                    .map(|(_, style)| *style)
+            });
+            let resolve_state_style = |vs: VisualState| {
+                class_style
+                    .map(|style| style.resolve(vs))
+                    .unwrap_or_else(|| render_node.style.resolve(vs))
+            };
+            let active_style = if let Some((from, to, t)) = self.state_transition_progress(node.id) {
+                lerp_style(resolve_state_style(from), resolve_state_style(to), t)
+            } else {
+                resolve_state_style(state)
+            };
+            render_node.style = render_node.style.with_state_override(state, active_style);
             if opacity < 255 {
                 let apply = |v: u8| -> u8 { ((v as u16 * opacity as u16) / 255) as u8 };
                 render_node.style.normal.opacity = apply(render_node.style.normal.opacity);
@@ -3361,7 +3647,8 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         Ok(())
     }
 
-    fn handle_pointer_released(&mut self, x: i32, y: i32) -> Result<(), GuiError> {
+    fn handle_pointer_released(&mut self, _x: i32, _y: i32) -> Result<(), GuiError> {
+        let mut released_id = None;
         if let Some(pressed) = self.pressed {
             if let Some(scroll_id) = self.scrollable_ancestor(pressed.id) {
                 if pressed.scroll_velocity.abs() > self.scroll_physics.velocity_threshold {
@@ -3371,16 +3658,34 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                     });
                 }
             }
+            released_id = Some(pressed.id);
         }
         self.pressed = None;
-        let hit = self.pointer_hit(x, y, true);
-        if let Some(id) = hit {
+        if let Some(id) = released_id {
+            let to = if !self.effective_enabled(id) {
+                VisualState::Disabled
+            } else if Some(id) == self.focus {
+                VisualState::Focused
+            } else {
+                VisualState::Normal
+            };
+            self.start_state_transition(id, VisualState::Pressed, to);
             let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
             self.dispatch_widget_event(id, WidgetEventKind::Released, &mut events, |_| {
                 EventPolicy::Continue
             })?;
             self.push_event(UiEvent::Released(id))?;
             self.push_event(UiEvent::PointerReleased(id))?;
+            let double_pointer = self.last_pointer_id == Some(id)
+                && self.pointer_elapsed_ms <= self.pointer_double_window_ms;
+            if double_pointer {
+                self.dispatch_double_clicked(id)?;
+                self.last_pointer_id = None;
+                self.pointer_elapsed_ms = 0;
+            } else {
+                self.last_pointer_id = Some(id);
+                self.pointer_elapsed_ms = 0;
+            }
         }
         Ok(())
     }
@@ -3442,6 +3747,12 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         if is_pointer {
             self.push_event(UiEvent::PointerPressed(id))?;
         }
+        let from = if Some(id) == self.focus {
+            VisualState::Focused
+        } else {
+            VisualState::Normal
+        };
+        self.start_state_transition(id, from, VisualState::Pressed);
 
         self.activate_focused(id)?;
         self.dispatch_widget_event(id, WidgetEventKind::Clicked, &mut events, |_| {
@@ -3459,6 +3770,30 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
         })?;
         self.push_event(UiEvent::Clicked(id))?;
         self.push_event(UiEvent::Activate(id))
+    }
+
+    fn dispatch_double_clicked(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+        self.dispatch_widget_event(id, WidgetEventKind::DoubleClicked, &mut events, |_| {
+            EventPolicy::Continue
+        })?;
+        self.push_event(UiEvent::DoubleClicked(id))
+    }
+
+    fn dispatch_key_pressed(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+        self.dispatch_widget_event(id, WidgetEventKind::Pressed, &mut events, |_| {
+            EventPolicy::Continue
+        })?;
+        self.push_event(UiEvent::Pressed(id))
+    }
+
+    fn dispatch_key_released(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        let mut events = heapless::Vec::<WidgetEvent, NODES>::new();
+        self.dispatch_widget_event(id, WidgetEventKind::Released, &mut events, |_| {
+            EventPolicy::Continue
+        })?;
+        self.push_event(UiEvent::Released(id))
     }
 
     fn repeatable_widget(&self, id: WidgetId) -> bool {
@@ -3558,9 +3893,11 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             return Ok(());
         }
         let mut i = 0usize;
+        let mut completed_pressed = heapless::Vec::<WidgetId, NODES>::new();
         while i < self.state_transitions.len() {
             let mut remove = false;
             let id;
+            let to;
             {
                 let entry = &mut self.state_transitions[i];
                 entry.elapsed_ms = entry.elapsed_ms.saturating_add(dt_ms);
@@ -3568,15 +3905,27 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
                     remove = true;
                 }
                 id = entry.id;
+                to = entry.to;
             }
             if let Some(rect) = self.absolute_rect(id) {
                 self.dirty.add(rect)?;
             }
             if remove {
+                if to == VisualState::Pressed {
+                    let _ = completed_pressed.push(id);
+                }
                 self.state_transitions.remove(i);
             } else {
                 i += 1;
             }
+        }
+        for id in completed_pressed {
+            // Pointer-held presses keep visual pressed state until release.
+            if self.pressed.is_some_and(|pressed| pressed.id == id) {
+                continue;
+            }
+            let to = self.resting_visual_state(id);
+            self.start_state_transition(id, VisualState::Pressed, to);
         }
         Ok(())
     }
@@ -3673,6 +4022,81 @@ impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize>
             .iter()
             .find(|(id, _)| *id == event.current)
             .is_some_and(|(_, policy)| policy.stop && policy.allows(event.kind, event.phase))
+    }
+
+    fn resting_visual_state(&self, id: WidgetId) -> VisualState {
+        if !self.effective_enabled(id) {
+            VisualState::Disabled
+        } else if Some(id) == self.focus {
+            VisualState::Focused
+        } else {
+            VisualState::Normal
+        }
+    }
+
+    fn current_visual_state(&self, id: WidgetId) -> VisualState {
+        if self.pressed.is_some_and(|pressed| pressed.id == id) {
+            VisualState::Pressed
+        } else {
+            self.resting_visual_state(id)
+        }
+    }
+
+    fn press_timing_for(&self, id: WidgetId) -> PressTiming {
+        self.widget_press_timings
+            .iter()
+            .find(|(timing_id, _)| *timing_id == id)
+            .map(|(_, timing)| *timing)
+            .unwrap_or(PressTiming {
+                long_press_ms: self.long_press_ms,
+                repeat_delay_ms: self.press_repeat_delay_ms,
+                repeat_interval_ms: self.press_repeat_interval_ms,
+            })
+    }
+
+    fn key_input_policy_for(&self, id: WidgetId) -> WidgetKeyInputPolicy {
+        self.widget_key_policies
+            .iter()
+            .find(|(policy_id, _)| *policy_id == id)
+            .map(|(_, policy)| *policy)
+            .unwrap_or_default()
+    }
+
+    fn key_bindings_for(&self, id: WidgetId) -> WidgetKeyBindings {
+        self.widget_key_bindings
+            .iter()
+            .find(|(binding_id, _)| *binding_id == id)
+            .map(|(_, bindings)| *bindings)
+            .unwrap_or_default()
+    }
+
+    fn handle_select_activation(&mut self, id: WidgetId) -> Result<(), GuiError> {
+        let double_select = self.last_select_id == Some(id)
+            && self.select_elapsed_ms <= self.select_double_window_ms;
+        self.dispatch_activation(id, false)?;
+        if double_select {
+            self.dispatch_double_clicked(id)?;
+            self.last_select_id = None;
+            self.select_elapsed_ms = 0;
+        } else {
+            self.last_select_id = Some(id);
+            self.select_elapsed_ms = 0;
+        }
+        Ok(())
+    }
+
+    fn handle_back_action(&mut self) -> Result<(), GuiError> {
+        if let Some(id) = self.focus {
+            if matches!(self.node(id).map(|n| n.kind), Some(WidgetKind::TextArea { .. })) {
+                self.textarea_backspace(id)?;
+                return Ok(());
+            }
+            if matches!(self.node(id).map(|n| n.kind), Some(WidgetKind::Dropdown { open: true, .. })) {
+                self.set_dropdown_open(id, false)?;
+                return Ok(());
+            }
+        }
+        self.push_event(UiEvent::Back)
     }
 }
 

--- a/src/input.rs
+++ b/src/input.rs
@@ -32,7 +32,11 @@ pub enum InputEvent {
     Undo,
     Redo,
     Select,
+    SelectPressed,
+    SelectReleased,
     Back,
+    BackPressed,
+    BackReleased,
     Encoder {
         delta: i8,
     },
@@ -55,6 +59,7 @@ pub enum UiEvent {
     Pressed(WidgetId),
     Released(WidgetId),
     Clicked(WidgetId),
+    DoubleClicked(WidgetId),
     LongPressed(WidgetId),
     Opened(WidgetId),
     Closed(WidgetId),
@@ -133,6 +138,7 @@ impl UiEvent {
             | Self::Pressed(id)
             | Self::Released(id)
             | Self::Clicked(id)
+            | Self::DoubleClicked(id)
             | Self::LongPressed(id)
             | Self::Opened(id)
             | Self::Closed(id)
@@ -159,6 +165,7 @@ impl UiEvent {
             | Self::Pressed(_)
             | Self::Released(_)
             | Self::Clicked(_)
+            | Self::DoubleClicked(_)
             | Self::LongPressed(_)
             | Self::Opened(_)
             | Self::Closed(_) => UiEventFilter::ACTIVATE,
@@ -179,6 +186,7 @@ pub enum WidgetEventKind {
     Pressed,
     Released,
     Clicked,
+    DoubleClicked,
     LongPressed,
     Opened,
     Closed,
@@ -238,7 +246,11 @@ impl WidgetEventKind {
     pub const fn filter(self) -> WidgetEventFilter {
         match self {
             Self::Pressed | Self::Released | Self::Gesture => WidgetEventFilter::POINTER,
-            Self::Clicked | Self::LongPressed | Self::Opened | Self::Closed => {
+            Self::Clicked
+            | Self::DoubleClicked
+            | Self::LongPressed
+            | Self::Opened
+            | Self::Closed => {
                 WidgetEventFilter::ACTIVATE
             }
             Self::ValueChanged => WidgetEventFilter::VALUE,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,9 @@ pub use animation_timeline::{
     SequencePlayer, SequencePlayerStatus, SequenceRepeatMode, TimelineError, TimelineStep,
 };
 pub use block::Block;
-pub use context::{GuiContext, GuiError};
+pub use context::{
+    GuiContext, GuiError, KeyBindingAction, PressTiming, WidgetKeyBindings, WidgetKeyInputPolicy,
+};
 pub use font::FontId;
 pub use geometry::{DirtyTracker, EdgeInsets, Rect};
 pub use input::{
@@ -90,6 +92,7 @@ pub mod prelude {
         AnimationManager, AnimationSequence, AnimationState, Axis, Block, Border, Constraint,
         DirtyTracker, Easing, EdgeInsets, EventContext, EventPhase, EventPhaseMask, EventPolicy,
         FocusGroupId, FontId, GradientDirection, GuiContext, GuiError, ImageAtlas,
+        PressTiming, WidgetKeyInputPolicy, WidgetKeyBindings, KeyBindingAction,
         ImageAtlasEntry, ImageFit, ImageRef, InputEvent, Keyframe, KeyframeTrack,
         KeyframeTrackCallbacks, LayoutItem, Length, Line, LinearGradient, LinearLayout,
         ListState, PointerButton, PointerState, PresentRegion, Rect, RenderCtx, RenderQuality,

--- a/tests/gui.rs
+++ b/tests/gui.rs
@@ -582,6 +582,61 @@ fn intrinsic_layout_can_preserve_cross_axis_size() {
 }
 
 #[test]
+fn nested_apply_layout_positions_children_relative_to_parent() {
+    let mut gui = GuiContext::<12, 16, 12>::new(Rect::new(0, 0, 120, 80));
+    let parent = gui
+        .add_panel(Rect::new(10, 12, 60, 30), Style::panel())
+        .unwrap();
+    let a = gui
+        .add_button(Rect::new(0, 0, 1, 1), "A", Style::button())
+        .unwrap();
+    let b = gui
+        .add_button(Rect::new(0, 0, 1, 1), "B", Style::button())
+        .unwrap();
+    gui.add_child(parent, a).unwrap();
+    gui.add_child(parent, b).unwrap();
+
+    gui.apply_layout(
+        LinearLayout::row().with_gap(2),
+        Rect::new(1, 2, 40, 10),
+        &[a, b],
+    )
+    .unwrap();
+
+    let a_abs = gui.absolute_rect(a).unwrap();
+    let b_abs = gui.absolute_rect(b).unwrap();
+    assert_eq!(a_abs, Rect::new(11, 14, 19, 10));
+    assert_eq!(b_abs, Rect::new(32, 14, 19, 10));
+}
+
+#[test]
+fn nested_layout_respects_parent_clip_children_for_overflowing_child() {
+    let mut gui = GuiContext::<12, 16, 12>::new(Rect::new(0, 0, 80, 40));
+    let parent = gui
+        .add_panel(Rect::new(6, 6, 20, 12), Style::panel())
+        .unwrap();
+    let child = gui
+        .add_label(Rect::new(0, 0, 1, 1), "OVERFLOW LABEL", Style::label())
+        .unwrap();
+    gui.add_child(parent, child).unwrap();
+
+    gui.apply_layout(
+        LinearLayout::row(),
+        Rect::new(0, 0, 40, 8),
+        &[child],
+    )
+    .unwrap();
+
+    let mut target = MockTarget::new(80, 40);
+    gui.render(&mut target).unwrap();
+    let leaked_pixels = target
+        .pixels
+        .iter()
+        .any(|&(x, y, _)| x > 26 && y >= 6 && y <= 18);
+    assert!(!leaked_pixels);
+}
+
+#[test]
 fn block_calculates_inner_area_and_renders_title() {
     let block = Block::styled(Style::panel()).title("HUD");
 
@@ -2192,6 +2247,167 @@ fn select_emits_pressed_clicked_activate_and_focus_events() {
 }
 
 #[test]
+fn double_select_emits_double_clicked_within_window() {
+    let mut gui = GuiContext::<4, 24, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_double_select_window_ms(40);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Select).unwrap();
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::DoubleClicked(button) {
+            panic!("unexpected double click on first select");
+        }
+    }
+
+    gui.tick_input(20).unwrap();
+    gui.handle_input(InputEvent::Select).unwrap();
+    let mut saw_double = false;
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::DoubleClicked(button) {
+            saw_double = true;
+        }
+    }
+    assert!(saw_double);
+}
+
+#[test]
+fn double_select_timeout_prevents_double_clicked_event() {
+    let mut gui = GuiContext::<4, 24, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_double_select_window_ms(20);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Select).unwrap();
+    while gui.pop_event().is_some() {}
+    gui.tick_input(25).unwrap();
+    gui.handle_input(InputEvent::Select).unwrap();
+
+    while let Some(event) = gui.pop_event() {
+        assert_ne!(event, UiEvent::DoubleClicked(button));
+    }
+}
+
+#[test]
+fn raw_select_policy_uses_press_release_then_activation() {
+    let mut gui = GuiContext::<4, 24, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_widget_key_input_policy(
+        button,
+        WidgetKeyInputPolicy {
+            raw_select: true,
+            raw_back: false,
+        },
+    )
+    .unwrap();
+    gui.set_focus(Some(button)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::SelectPressed).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::Pressed(button)));
+
+    gui.handle_input(InputEvent::SelectReleased).unwrap();
+    let mut saw_released = false;
+    let mut saw_pressed = false;
+    let mut saw_clicked = false;
+    let mut saw_activate = false;
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::Released(button) {
+            saw_released = true;
+        } else if event == UiEvent::Pressed(button) {
+            saw_pressed = true;
+        } else if event == UiEvent::Clicked(button) {
+            saw_clicked = true;
+        } else if event == UiEvent::Activate(button) {
+            saw_activate = true;
+        }
+    }
+    assert!(saw_released && saw_pressed && saw_clicked && saw_activate);
+}
+
+#[test]
+fn raw_back_policy_emits_press_release_and_runs_back_action() {
+    static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 64, 32));
+    let dropdown = gui
+        .add_dropdown(Rect::new(0, 0, 40, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    gui.set_widget_key_input_policy(
+        dropdown,
+        WidgetKeyInputPolicy {
+            raw_select: false,
+            raw_back: true,
+        },
+    )
+    .unwrap();
+    gui.set_focus(Some(dropdown)).unwrap();
+    gui.set_dropdown_open(dropdown, true).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::BackPressed).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::Pressed(dropdown)));
+
+    gui.handle_input(InputEvent::BackReleased).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::Released(dropdown)));
+    assert_eq!(gui.pop_event(), Some(UiEvent::Closed(dropdown)));
+    assert_eq!(gui.dropdown_open(dropdown), Some(false));
+}
+
+#[test]
+fn widget_key_binding_can_ignore_select_activation() {
+    let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_widget_key_bindings(
+        button,
+        WidgetKeyBindings {
+            select: KeyBindingAction::Ignore,
+            back: KeyBindingAction::Default,
+        },
+    )
+    .unwrap();
+    gui.set_focus(Some(button)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Select).unwrap();
+    assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn widget_key_binding_can_remap_back_to_activate() {
+    let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_widget_key_bindings(
+        button,
+        WidgetKeyBindings {
+            select: KeyBindingAction::Default,
+            back: KeyBindingAction::Activate,
+        },
+    )
+    .unwrap();
+    gui.set_focus(Some(button)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Back).unwrap();
+    let mut saw_activate = false;
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::Activate(button) {
+            saw_activate = true;
+        }
+    }
+    assert!(saw_activate);
+}
+
+#[test]
 fn pointer_release_emits_release_events() {
     let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
     let button = gui
@@ -2202,6 +2418,140 @@ fn pointer_release_emits_release_events() {
     gui.handle_input(InputEvent::Pointer {
         x: 2,
         y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+
+    assert_eq!(gui.pop_event(), Some(UiEvent::Released(button)));
+    assert_eq!(gui.pop_event(), Some(UiEvent::PointerReleased(button)));
+}
+
+#[test]
+fn pointer_double_click_emits_double_clicked_within_window() {
+    let mut gui = GuiContext::<4, 24, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_double_pointer_window_ms(40);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while let Some(event) = gui.pop_event() {
+        assert_ne!(event, UiEvent::DoubleClicked(button));
+    }
+
+    gui.tick_input(20).unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    let mut saw_double = false;
+    while let Some(event) = gui.pop_event() {
+        if event == UiEvent::DoubleClicked(button) {
+            saw_double = true;
+        }
+    }
+    assert!(saw_double);
+}
+
+#[test]
+fn pointer_double_click_timeout_prevents_double_clicked_event() {
+    let mut gui = GuiContext::<4, 24, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_double_pointer_window_ms(20);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+    gui.tick_input(25).unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+
+    while let Some(event) = gui.pop_event() {
+        assert_ne!(event, UiEvent::DoubleClicked(button));
+    }
+}
+
+#[test]
+fn pointer_release_reports_pressed_widget_even_when_pointer_leaves_hit_rect() {
+    let mut gui = GuiContext::<4, 16, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 20, 10), "ONE", Style::button())
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 40,
+        y: 20,
         state: PointerState::Released,
         button: PointerButton::Primary,
     })
@@ -2306,6 +2656,104 @@ fn dropdown_emits_open_close_events() {
 }
 
 #[test]
+fn back_input_closes_focused_open_dropdown_before_global_back() {
+    static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 64, 32));
+    let dropdown = gui
+        .add_dropdown(Rect::new(0, 0, 40, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    gui.set_focus(Some(dropdown)).unwrap();
+    gui.set_dropdown_open(dropdown, true).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Back).unwrap();
+
+    assert_eq!(gui.dropdown_open(dropdown), Some(false));
+    assert_eq!(gui.pop_event(), Some(UiEvent::Closed(dropdown)));
+    assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn dropdown_navigation_wraps_with_up_down_when_open() {
+    static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 64, 32));
+    let dropdown = gui
+        .add_dropdown(Rect::new(0, 0, 40, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    gui.set_focus(Some(dropdown)).unwrap();
+    gui.set_dropdown_open(dropdown, true).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Up).unwrap();
+    assert_eq!(gui.dropdown_selected(dropdown), Some(2));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(dropdown)));
+
+    gui.handle_input(InputEvent::Down).unwrap();
+    assert_eq!(gui.dropdown_selected(dropdown), Some(0));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(dropdown)));
+}
+
+#[test]
+fn list_navigation_updates_selection_and_offset() {
+    static ITEMS: [&str; 5] = ["A", "B", "C", "D", "E"];
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 80, 40));
+    let list = gui
+        .add_list(Rect::new(0, 0, 40, 20), &ITEMS, 0, 2, Style::panel())
+        .unwrap();
+    gui.set_focus(Some(list)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Down).unwrap();
+    gui.handle_input(InputEvent::Down).unwrap();
+    gui.handle_input(InputEvent::Down).unwrap();
+
+    assert_eq!(gui.list_selected(list), Some(3));
+    let node = gui.widgets().iter().find(|w| w.id == list).unwrap();
+    match node.kind {
+        WidgetKind::List { offset, .. } => assert_eq!(offset, 2),
+        _ => panic!("expected list widget"),
+    }
+}
+
+#[test]
+fn tabs_left_right_and_encoder_wrap_selection() {
+    static TABS: [&str; 3] = ["A", "B", "C"];
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 80, 32));
+    let tabs = gui
+        .add_tabs(Rect::new(0, 0, 60, 12), &TABS, 0, Style::button())
+        .unwrap();
+    gui.set_focus(Some(tabs)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Left).unwrap();
+    assert_eq!(gui.tab_selected(tabs), Some(2));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(tabs)));
+
+    gui.handle_input(InputEvent::Right).unwrap();
+    assert_eq!(gui.tab_selected(tabs), Some(0));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(tabs)));
+}
+
+#[test]
+fn roller_navigation_wraps_selection() {
+    static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 80, 32));
+    let roller = gui
+        .add_roller(Rect::new(0, 0, 40, 18), &ITEMS, 0, Style::button())
+        .unwrap();
+    gui.set_focus(Some(roller)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Up).unwrap();
+    assert_eq!(gui.roller_selected(roller), Some(2));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(roller)));
+
+    gui.handle_input(InputEvent::Down).unwrap();
+    assert_eq!(gui.roller_selected(roller), Some(0));
+    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(roller)));
+}
+
+#[test]
 fn textarea_edit_hooks_emit_text_input_events() {
     let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 64, 32));
     let textarea = gui
@@ -2327,14 +2775,7 @@ fn textarea_edit_hooks_emit_text_input_events() {
         })
     );
     assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(textarea)));
-    assert_eq!(
-        gui.pop_event(),
-        Some(UiEvent::TextInput {
-            id: textarea,
-            ch: '\u{7f}'
-        })
-    );
-    assert_eq!(gui.pop_event(), Some(UiEvent::ValueChanged(textarea)));
+    assert_eq!(gui.pop_event(), None);
 }
 
 #[test]
@@ -2500,6 +2941,44 @@ fn textarea_undo_redo_restores_mutation_history() {
 }
 
 #[test]
+fn textarea_undo_redo_tracks_selection_replace_boundaries() {
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 96, 32));
+    let textarea = gui
+        .add_textarea(Rect::new(0, 0, 80, 14), "HELLO WORLD", "TYPE", Style::panel())
+        .unwrap();
+    gui.set_focus(Some(textarea)).unwrap();
+    gui.set_textarea_selection(textarea, 6, 11).unwrap();
+    gui.set_textarea_cursor(textarea, 11).unwrap();
+
+    gui.textarea_insert_char(textarea, '!').unwrap();
+    assert_eq!(gui.textarea_text(textarea), Some("HELLO !"));
+
+    gui.handle_input(InputEvent::Undo).unwrap();
+    assert_eq!(gui.textarea_text(textarea), Some("HELLO WORLD"));
+
+    gui.handle_input(InputEvent::Redo).unwrap();
+    assert_eq!(gui.textarea_text(textarea), Some("HELLO !"));
+}
+
+#[test]
+fn textarea_wrapped_selection_replace_can_be_undone() {
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 96, 32));
+    let textarea = gui
+        .add_textarea(Rect::new(0, 0, 18, 14), "ABCDEFGH", "TYPE", Style::panel())
+        .unwrap();
+    gui.set_focus(Some(textarea)).unwrap();
+    gui.set_textarea_cursor(textarea, 6).unwrap();
+    gui.handle_input(InputEvent::SelectHome).unwrap();
+    assert_eq!(gui.textarea_selection(textarea), Some((4, 6)));
+
+    gui.textarea_insert_char(textarea, 'Z').unwrap();
+    assert_eq!(gui.textarea_text(textarea), Some("ABCDZGH"));
+
+    gui.handle_input(InputEvent::Undo).unwrap();
+    assert_eq!(gui.textarea_text(textarea), Some("ABCDEFGH"));
+}
+
+#[test]
 fn textarea_read_only_blocks_mutation_ops() {
     let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 96, 32));
     let textarea = gui
@@ -2532,6 +3011,55 @@ fn textarea_single_line_rejects_newline_insert() {
 
     gui.textarea_insert_char(textarea, 'X').unwrap();
     assert_eq!(gui.textarea_text(textarea), Some("ONEX"));
+}
+
+#[test]
+fn textarea_noop_backspace_does_not_emit_events() {
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 96, 32));
+    let textarea = gui
+        .add_textarea(Rect::new(0, 0, 80, 14), "A", "TYPE", Style::panel())
+        .unwrap();
+    gui.set_textarea_cursor(textarea, 0).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.textarea_backspace(textarea).unwrap();
+
+    assert_eq!(gui.textarea_text(textarea), Some("A"));
+    assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn textarea_noop_delete_forward_does_not_emit_events() {
+    let mut gui = GuiContext::<8, 32, 8>::new(Rect::new(0, 0, 96, 32));
+    let textarea = gui
+        .add_textarea(Rect::new(0, 0, 80, 14), "A", "TYPE", Style::panel())
+        .unwrap();
+    gui.set_textarea_cursor(textarea, 1).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.textarea_delete_forward(textarea).unwrap();
+
+    assert_eq!(gui.textarea_text(textarea), Some("A"));
+    assert_eq!(gui.pop_event(), None);
+}
+
+#[test]
+fn textarea_select_home_and_end_follow_wrapped_line_boundaries() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 96, 32));
+    let textarea = gui
+        .add_textarea(Rect::new(0, 0, 18, 14), "ABCDEFGH", "TYPE", Style::panel())
+        .unwrap();
+    gui.set_focus(Some(textarea)).unwrap();
+    gui.set_textarea_cursor(textarea, 6).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::SelectHome).unwrap();
+    assert_eq!(gui.textarea_cursor(textarea), Some(4));
+    assert_eq!(gui.textarea_selection(textarea), Some((4, 6)));
+
+    gui.handle_input(InputEvent::SelectEnd).unwrap();
+    assert_eq!(gui.textarea_cursor(textarea), Some(8));
+    assert_eq!(gui.textarea_selection(textarea), Some((6, 8)));
 }
 
 #[test]
@@ -2685,6 +3213,62 @@ fn long_press_repeat_emits_repeated_activate_for_button() {
 }
 
 #[test]
+fn widget_press_timing_override_controls_long_press_and_repeat() {
+    let mut gui = GuiContext::<4, 32, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_long_press_threshold_ms(1000);
+    gui.set_press_repeat_timing(1000, 1000);
+    gui.set_widget_press_timing(button, PressTiming::new(10, 20, 10))
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.tick_input(10).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::LongPressed(button)));
+    assert_eq!(gui.pop_event(), None);
+
+    gui.tick_input(20).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::Clicked(button)));
+    assert_eq!(gui.pop_event(), Some(UiEvent::Activate(button)));
+}
+
+#[test]
+fn clearing_widget_press_timing_reverts_to_global_behavior() {
+    let mut gui = GuiContext::<4, 32, 4>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", Style::button())
+        .unwrap();
+    gui.set_long_press_threshold_ms(40);
+    gui.set_widget_press_timing(button, PressTiming::new(10, 20, 10))
+        .unwrap();
+    gui.clear_widget_press_timing(button).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    while gui.pop_event().is_some() {}
+    gui.tick_input(10).unwrap();
+    assert_eq!(gui.pop_event(), None);
+    gui.tick_input(30).unwrap();
+    assert_eq!(gui.pop_event(), Some(UiEvent::LongPressed(button)));
+}
+
+#[test]
 fn drag_release_continues_scroll_with_inertia() {
     let mut gui = GuiContext::<8, 48, 8>::new(Rect::new(0, 0, 64, 32));
     let scroll = gui
@@ -2824,6 +3408,99 @@ fn focus_state_transitions_progress_and_complete() {
 }
 
 #[test]
+fn pressed_state_uses_pressed_style_while_pointer_is_held() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let pressed_bg = Rgb565::new(31, 0, 0);
+    let normal_bg = Rgb565::new(0, 0, 4);
+    let normal = Style {
+        background: Some(normal_bg),
+        gradient: None,
+        font: FontId::Tiny3x5,
+        foreground: Rgb565::WHITE,
+        text: Rgb565::WHITE,
+        accent: Rgb565::CYAN,
+        opacity: 255,
+        corner_radius: 0,
+        shadow: None,
+        border: Border::none(),
+        padding: EdgeInsets::all(0),
+    };
+    let styles = WidgetStyle::new(normal).with_pressed(Style {
+        background: Some(pressed_bg),
+        ..normal
+    });
+    let _button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "ONE", styles)
+        .unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+
+    let mut target = MockTarget::new(64, 32);
+    gui.render(&mut target).unwrap();
+    assert!(target.pixels.iter().any(|&(_, _, c)| c == pressed_bg));
+}
+
+#[test]
+fn pressed_state_transitions_progress_and_complete_on_release() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let _button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "A", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(30);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+
+    gui.tick_input(10).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+    gui.tick_input(40).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
+fn select_activation_runs_pressed_feedback_transition_cycle() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 30, 10), "A", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(20);
+    gui.set_focus(Some(button)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Select).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+
+    gui.tick_input(20).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+
+    gui.tick_input(25).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
 fn zero_duration_disables_state_transition_queue() {
     let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
     let first = gui
@@ -2836,6 +3513,75 @@ fn zero_duration_disables_state_transition_queue() {
     gui.set_focus(Some(first)).unwrap();
     gui.set_focus(Some(second)).unwrap();
     assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
+fn disabling_widget_starts_transition_toward_disabled_state() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let first = gui
+        .add_button(Rect::new(0, 0, 20, 10), "A", Style::button())
+        .unwrap();
+    let _second = gui
+        .add_button(Rect::new(0, 12, 20, 10), "B", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(20);
+    gui.set_focus(Some(first)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.set_disabled(first, true).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+
+    gui.tick_input(25).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
+fn enabling_widget_starts_transition_back_to_resting_state() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 20, 10), "A", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(20);
+    gui.set_disabled(button, true).unwrap();
+    gui.tick_input(25).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.set_disabled(button, false).unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+
+    gui.tick_input(25).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
+}
+
+#[test]
+fn disabling_pressed_widget_clears_pressed_state_immediately() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 24, 10), "A", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(20);
+    while gui.pop_event().is_some() {}
+
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Pressed,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+    assert!(gui.active_state_transitions() >= 1);
+    while gui.pop_event().is_some() {}
+
+    gui.set_disabled(button, true).unwrap();
+    gui.handle_input(InputEvent::Pointer {
+        x: 2,
+        y: 2,
+        state: PointerState::Released,
+        button: PointerButton::Primary,
+    })
+    .unwrap();
+
+    assert_eq!(gui.pop_event(), None);
 }
 
 #[test]
@@ -2995,6 +3741,75 @@ fn style_class_state_override_applies_only_in_state() {
         .filter(|&&(_, _, c)| c == focused_bg)
         .count();
     assert!(focused_count > normal_count);
+}
+
+#[test]
+fn class_state_overrides_apply_to_transition_endpoints() {
+    let mut gui = GuiContext::<8, 8, 8>::new(Rect::new(0, 0, 40, 20));
+    let base = Style {
+        background: Some(Rgb565::BLUE),
+        gradient: None,
+        font: FontId::Tiny3x5,
+        foreground: Rgb565::WHITE,
+        text: Rgb565::WHITE,
+        accent: Rgb565::WHITE,
+        opacity: 255,
+        corner_radius: 0,
+        shadow: None,
+        border: Border::none(),
+        padding: EdgeInsets::all(0),
+    };
+    let button = gui
+        .add_button(Rect::new(2, 2, 24, 10), "", WidgetStyle::new(base))
+        .unwrap();
+    let class = StyleClassId::new(7);
+    gui.set_widget_style_class(button, Some(class)).unwrap();
+    gui.set_style_class_state(
+        class,
+        VisualState::Normal,
+        Style {
+            background: Some(Rgb565::BLACK),
+            ..base
+        },
+    )
+    .unwrap();
+    gui.set_style_class_state(
+        class,
+        VisualState::Focused,
+        Style {
+            background: Some(Rgb565::RED),
+            ..base
+        },
+    )
+    .unwrap();
+    gui.set_state_transition_duration_ms(100);
+    gui.set_focus(Some(button)).unwrap();
+    while gui.pop_event().is_some() {}
+    gui.set_focus(None).unwrap();
+    gui.tick_input(50).unwrap();
+
+    let mut target = TestBuffer::new(40, 20);
+    gui.render(&mut target).unwrap();
+    let mid = target.pixel_at(8, 6).unwrap_or(Rgb565::BLACK);
+    assert!(mid.r() > 0);
+}
+
+#[test]
+fn state_transition_for_widget_is_replaced_by_new_state_change() {
+    let mut gui = GuiContext::<8, 16, 8>::new(Rect::new(0, 0, 64, 32));
+    let button = gui
+        .add_button(Rect::new(0, 0, 20, 10), "A", Style::button())
+        .unwrap();
+    gui.set_state_transition_duration_ms(80);
+    gui.set_focus(Some(button)).unwrap();
+    while gui.pop_event().is_some() {}
+
+    gui.set_focus(None).unwrap();
+    assert_eq!(gui.active_state_transitions(), 1);
+    gui.set_disabled(button, true).unwrap();
+    assert_eq!(gui.active_state_transitions(), 1);
+    gui.tick_input(100).unwrap();
+    assert_eq!(gui.active_state_transitions(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add configurable per-widget press timing, double-click recognition, and raw key press/release handling
- add per-widget key input policies and key binding overrides for `Select`/`Back`
- expand regression coverage for interaction semantics, state transitions, textarea edge cases, and key policy behavior

## Test plan
- [x] `cargo test`