### PR TITLE
Update README and add interaction behavior contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,32 @@
 # embedded-gui
 
-`embedded-gui` is a small `no_std` GUI/HUD crate for `embedded-graphics` displays.
+`embedded-gui` is a `no_std` GUI/HUD crate for `embedded-graphics` displays.
+It is built around fixed-capacity data structures, deterministic rendering, and
+embedded-friendly interaction patterns (pointer, encoder, and keyboard-style input).
 
-The first milestone is intentionally focused: labels, panels, buttons, progress bars,
-menus, fixed-capacity storage, button/encoder navigation, and dirty-region tracking.
-It is designed to render after an `embedded-3dgfx` frame, but it does not depend on
-the 3D engine at runtime.
+## Current State
+
+`embedded-gui` currently provides a broad baseline of widgets, interaction semantics,
+fixed-capacity animation primitives, and screen transition tooling for embedded UIs.
+Recent work has focused on tightening interaction fidelity, expanding state transition
+coverage, and improving regression-focused examples/docs.
+
+- Pointer release semantics now consistently target the originally pressed widget.
+- Focused open dropdowns now close on `Back` before global back handling.
+- State transitions now cover keyboard and pointer press feedback paths.
+- Enabled/disabled flag changes now participate in state transitions with regression coverage.
+- Style-class state overrides now participate correctly in transition endpoint blending.
+- Select activation now supports configurable double-select recognition (`DoubleClicked` events).
+- Per-widget raw key input policy now supports `SelectPressed/Released` and `BackPressed/Released`.
+- Pointer interaction now supports configurable double-click recognition (`DoubleClicked` events).
+- Per-widget key bindings can override `Select`/`Back` behavior (`Default`, `Ignore`, `Activate`, `Back`).
+- Textarea no-op edits avoid emitting mutation events, with regression coverage.
+- Wrapped-line selection navigation (`SelectHome`/`SelectEnd`) now has dedicated edge-case coverage.
+- Cross-widget interaction matrix coverage now includes dropdown/list/tabs/roller keyboard navigation paths.
+- Nested layout + clip behavior now has dedicated regression coverage for parent-relative composition.
+- A dedicated interaction semantics simulator example is available in `examples/interaction_semantics_showcase.rs`.
+
+## Quick Start
 
 ```rust
 use embedded_gui::prelude::*;
@@ -15,6 +36,42 @@ gui.add_label(Rect::new(4, 4, 80, 8), "READY", Style::label())?;
 gui.add_progress_bar(Rect::new(4, 18, 80, 8), 0.6, Style::progress())?;
 gui.render(&mut display)?;
 ```
+
+## Implemented Feature Surface
+
+### Widgets and primitives
+
+The current widget set includes:
+
+- labels, panels, buttons, icon buttons, borders/spacers
+- progress bars, sliders, toggles, checkboxes, value labels
+- lists, menus, tabs, dialogs, toasts, scroll views
+- dropdowns, rollers, tables
+- chart (line and bars), spinner, meter/gauge/arc gauge/needle
+- textareas and on-screen keyboards
+- image widgets (`ImageRef`, `ImageFit`, atlas/sprite helpers)
+
+### Input and events
+
+- `InputEvent` supports D-pad/encoder navigation, pointer events, and text-editing-oriented key events
+- UI-level events (`UiEvent`) and widget-level events (`WidgetEvent`) are both exposed
+- Event flow supports capture, target, and bubble phases with filterable dispatch policy hooks
+- Pointer semantics include long-press, gesture dispatch, drag scrolling, inertia, and press-repeat timing hooks
+
+### Layout, styling, and text
+
+- `LinearLayout` and constraint-based item layout (`Length`, `Min/Max`, `Percent`, `Ratio`, `Fill`)
+- Style model with stateful variants (`normal`, `focused`, `pressed`, `disabled`)
+- Style interpolation and transition primitives (`StyleTransition`, `lerp_style`)
+- Text layout primitives (`Span`, `Line`, `Text`) with alignment, wrapping, spacing, overflow controls
+- Text shaping interface (`TextShaper`) with a basic shaping implementation for embedded-safe defaults
+
+### Animation and transitions
+
+- Core animation manager and easing/tween/path/spring/inertia primitives
+- Widget property animation (`WidgetAnimator`) and preset helpers (`presets`)
+- Timeline/keyframe sequencing support (`AnimationSequence`, `SequencePlayer`)
+- Screen stack + transition primitives for app-level flows
 
 ## Animation Quickstart
 
@@ -35,7 +92,7 @@ gui.clear_dirty();
 
 ## Textarea Editing Input
 
-Textarea widgets now support editor-style navigation and mutation events:
+Textarea widgets support editor-style navigation and mutation events, including:
 
 - `InputEvent::WordLeft` / `InputEvent::WordRight`
 - `InputEvent::Home` / `InputEvent::End`
@@ -43,7 +100,7 @@ Textarea widgets now support editor-style navigation and mutation events:
 - `InputEvent::Undo` / `InputEvent::Redo`
 - selection-replace behavior on typing/backspace/delete
 
-See `docs/textarea-input-keybindings.md` for mappings and a loop snippet.
+See `docs/textarea-input-keybindings.md` for mappings and loop snippets.
 
 ## Font Glyph Overrides
 
@@ -72,15 +129,38 @@ space:000,000,000,000,000
 
 Unspecified glyphs fall back to built-in defaults in `build.rs`.
 
-### Preview helper
-
-Use the helper script to preview glyph rows before building:
+Preview helper:
 
 ```bash
 python3 scripts/preview_glyphs.py assets/fonts/ascii_3x5.txt "?!@"
 ```
 
-The script prints a small ASCII visualization for each requested glyph.
+## Examples
+
+The `examples/` folder currently includes:
+
+- `widgets_showcase.rs`
+- `dashboard_app.rs`
+- `simulator_menu.rs`
+- `event_dispatch_showcase.rs`
+- `interaction_semantics_showcase.rs`
+- `raw_key_input_showcase.rs`
+- `form_flow_showcase.rs`
+- `complex_layout_showcase.rs`
+- `input_gesture_drag_repeat_showcase.rs`
+- `long_press_input_showcase.rs`
+- `text_layout_showcase.rs`
+- `font_text_model_showcase.rs`
+- `animation_motion_showcase.rs`
+- `animation_kitchen_sink_showcase.rs`
+- `animation_dirty_showcase.rs`
+- `timeline_transition_showcase.rs`
+- `visual_quality_showcase.rs`
+- `embedded_3dgfx_overlay.rs`
+
+## Behavior Notes
+
+- Input and widget interaction guarantees are documented in `docs/interaction-behavior-contract.md`.
 
 ## Example Screenshots
 

--- a/docs/interaction-behavior-contract.md
+++ b/docs/interaction-behavior-contract.md
@@ -1,0 +1,62 @@
+# Interaction Behavior Contract
+
+This document captures the expected interaction semantics for high-traffic widgets and shared input paths.
+
+## Pointer Press/Release
+
+- Pointer press targets the topmost clickable, visible, enabled widget under the cursor.
+- Pointer release emits release events for the originally pressed widget.
+- Release does not retarget to a different widget if the pointer ends outside the original hit rectangle.
+- Scroll inertia can continue after release if drag velocity exceeds the configured threshold.
+- Two pointer click cycles on the same widget within the configured pointer double-click window emit `DoubleClicked`.
+
+## Dropdown
+
+- `Select` toggles open/closed state on the focused dropdown.
+- While open, `Up` and `Down` cycle selection.
+- `Back` closes the focused open dropdown before emitting a global back event.
+- Opening and closing emit `Opened` and `Closed` events respectively.
+
+## Select Activation
+
+- `Select` emits the standard activation path (`Pressed`, `Clicked`, `Activate`) for the focused widget.
+- Two `Select` activations on the same focused widget within the configured double-select window
+  emit `DoubleClicked` after the second activation.
+- If the double-select window expires, the next `Select` starts a new click sequence.
+
+## Raw Key Input Policy
+
+- Widgets can opt into raw key semantics via per-widget key input policy.
+- With `raw_select` enabled:
+  - `SelectPressed` emits `Pressed` without immediate activation.
+  - `SelectReleased` emits `Released`, then runs the standard select activation path.
+- With `raw_back` enabled:
+  - `BackPressed` emits `Pressed`.
+  - `BackReleased` emits `Released`, then runs normal back behavior (including dropdown close-on-back).
+
+## Per-widget Key Bindings
+
+- Widgets can override `Select` and `Back` key behavior independently.
+- Each key supports:
+  - `Default`: preserve normal behavior
+  - `Ignore`: consume key without action
+  - `Activate`: run focused activation path
+  - `Back`: run back action path
+
+## Textarea
+
+- Backspace/delete and insertion mutations emit `TextInput` and `ValueChanged`.
+- No-op edit attempts do not emit mutation events.
+  - Example: backspace at cursor 0 with no selection.
+  - Example: delete-forward at end of text with no selection.
+- Selection replacement semantics apply before insertion and deletion.
+- Read-only textareas ignore mutation requests.
+
+## Visual State Priority
+
+Render-time visual state selection uses this priority:
+
+1. `Pressed` when a pointer press is actively held on a widget.
+2. `Focused` when the widget currently owns focus.
+3. `Disabled` when the widget or an ancestor is disabled.
+4. `Normal` otherwise.


### PR DESCRIPTION
## Summary
- rewrite README sections to reflect current embedded-gui capabilities and interaction semantics
- add `docs/interaction-behavior-contract.md` to codify input, focus, and event dispatch guarantees
- align docs with the newly added recognizer and key policy behavior from the base branch

## Test plan
- [x] docs-only changes reviewed for consistency with code