### PR TITLE
Add focused simulator showcase examples

### DIFF
--- a/examples/animation_motion_showcase.rs
+++ b/examples/animation_motion_showcase.rs
@@ -1,0 +1,221 @@
+use embedded_graphics_core::{
+    draw_target::DrawTarget,
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 240;
+const H: u32 = 140;
+const FRAME_MS: u32 = 16;
+const STAGE_COUNT: i32 = 4;
+
+static TABS: [&str; 4] = ["NAV", "FX", "IO", "SYS"];
+static ITEMS: [&str; 8] = ["ALPHA", "BETA", "GAMMA", "DELTA", "SIGMA", "OMEGA", "ION", "ARC"];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("animation motion showcase", &settings);
+    let mut gui = GuiContext::<48, 48, 32>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+
+    let mut animator = WidgetAnimator::<64, 64>::new();
+    let mut stage = 0_i32;
+    start_stage(&mut gui, &mut animator, &ids, stage);
+
+    'running: loop {
+        animator.tick(FRAME_MS, &mut gui).unwrap();
+        gui.tick_spinner(ids.spinner, FRAME_MS, 0.45).unwrap();
+
+        if animator.active_count() == 0 {
+            stage = (stage + 1) % STAGE_COUNT;
+            start_stage(&mut gui, &mut animator, &ids, stage);
+        }
+
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Space => start_stage(&mut gui, &mut animator, &ids, stage),
+                    Keycode::Tab => {
+                        stage = (stage + 1) % STAGE_COUNT;
+                        start_stage(&mut gui, &mut animator, &ids, stage);
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(FRAME_MS as u64));
+    }
+}
+
+struct Ids {
+    stage_label: WidgetId,
+    progress: WidgetId,
+    meter: WidgetId,
+    slider: WidgetId,
+    scroll: WidgetId,
+    sweep_panel: WidgetId,
+    tabs: WidgetId,
+    dropdown: WidgetId,
+    roller: WidgetId,
+    gauge: WidgetId,
+    spinner: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 48, 48, 32>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 228, 128), Style::panel()).unwrap();
+    gui.add_label(
+        Rect::new(12, 10, 216, 8),
+        "SPACE replay stage | TAB next stage",
+        Style::label(),
+    )
+    .unwrap();
+
+    let stage_label = gui
+        .add_value_label(Rect::new(12, 20, 68, 10), "STAGE", 0, Style::panel())
+        .unwrap();
+    let progress = gui
+        .add_progress_bar(Rect::new(12, 34, 94, 10), 0.0, Style::progress())
+        .unwrap();
+    let meter = gui
+        .add_meter(Rect::new(12, 48, 44, 26), 0.0, 0.0, 1.0, Style::progress())
+        .unwrap();
+    let slider = gui
+        .add_slider(Rect::new(62, 54, 44, 12), 0.0, 0.0, 1.0, Style::button())
+        .unwrap();
+
+    let scroll = gui
+        .add_scroll_view(Rect::new(12, 78, 94, 48), 0, 176, Style::panel())
+        .unwrap();
+    let list = gui
+        .add_list(Rect::new(4, 4, 86, 160), &ITEMS, 0, 8, Style::button())
+        .unwrap();
+    gui.add_child(scroll, list).unwrap();
+
+    let sweep_panel = gui
+        .add_panel(Rect::new(112, 24, 48, 28), Style::panel())
+        .unwrap();
+    let tabs = gui
+        .add_tabs(Rect::new(164, 24, 64, 12), &TABS, 0, Style::button())
+        .unwrap();
+    let dropdown = gui
+        .add_dropdown(Rect::new(164, 40, 64, 12), &ITEMS, 0, Style::button())
+        .unwrap();
+    let roller = gui
+        .add_roller(Rect::new(112, 58, 48, 64), &ITEMS, 0, Style::button())
+        .unwrap();
+    let gauge = gui
+        .add_gauge(Rect::new(164, 58, 34, 34), 0.0, 0.0, 1.0, Style::progress())
+        .unwrap();
+    gui.set_gauge_ticks(gauge, 7, 2, true).unwrap();
+    let spinner = gui
+        .add_spinner(Rect::new(202, 58, 26, 26), 0.0, Style::progress())
+        .unwrap();
+
+    Ids {
+        stage_label,
+        progress,
+        meter,
+        slider,
+        scroll,
+        sweep_panel,
+        tabs,
+        dropdown,
+        roller,
+        gauge,
+        spinner,
+    }
+}
+
+fn start_stage(
+    gui: &mut GuiContext<'static, 48, 48, 32>,
+    animator: &mut WidgetAnimator<64, 64>,
+    ids: &Ids,
+    stage: i32,
+) {
+    gui.set_value_label(ids.stage_label, stage).unwrap();
+
+    match stage {
+        // Stage 0: long horizontal/vertical sweeps + scrolling motion.
+        0 => {
+            let _ = animator.animate_scroll_offset_y(ids.scroll, 0, 120, 1450, Easing::InOutSine);
+            let _ = animator.animate_widget_x(ids.sweep_panel, 112, 132, 1200, Easing::InOutBack);
+            let _ = animator.animate_widget_y(ids.sweep_panel, 24, 36, 1200, Easing::InOutSine);
+            let _ = animator.animate_gauge_value(ids.gauge, 0.0, 1.0, 1200, Easing::OutExpo);
+            let _ = animator.animate_spinner_phase(ids.spinner, 0.0, 2.2, 1300, Easing::Linear);
+        }
+        // Stage 1: orbit/path and accent-color shifts.
+        1 => {
+            let _ = animator.animate_widget_path(
+                ids.spinner,
+                &[
+                    PathPoint::new(202.0, 58.0),
+                    PathPoint::new(210.0, 64.0),
+                    PathPoint::new(202.0, 74.0),
+                    PathPoint::new(194.0, 64.0),
+                    PathPoint::new(202.0, 58.0),
+                ],
+                1400,
+                Easing::InOutSine,
+            );
+            let _ = animator.animate_corner_radius(ids.sweep_panel, 0, 6, 1200, Easing::InOutSine);
+            let _ = animator.animate_accent_color(
+                ids.sweep_panel,
+                Rgb565::new(0, 28, 31),
+                Rgb565::new(31, 18, 0),
+                1200,
+                Easing::InOutSine,
+            );
+            let _ = animator.preset_attention_shake(ids.sweep_panel, 112, 3, 800);
+            let _ = animator.animate_scroll_offset_y(ids.scroll, 120, 24, 1200, Easing::OutCubic);
+        }
+        // Stage 2: pulse/compression with fade + springy values.
+        2 => {
+            let _ = animator.preset_fade_in_up(ids.sweep_panel, 36, 24, 760);
+            let _ = animator.animate_widget_width(ids.sweep_panel, 48, 40, 920, Easing::InOutSine);
+            let _ = animator.animate_widget_height(ids.sweep_panel, 28, 34, 920, Easing::InOutSine);
+            let _ = animator.animate_opacity(ids.sweep_panel, 80, 255, 920, Easing::InOutSine);
+            let _ = animator.animate_meter(ids.meter, 0.0, 1.0, 950, Easing::OutElastic);
+            let _ = animator.animate_slider_value(ids.slider, 0.0, 1.0, 950, Easing::InOutBack);
+            let _ = animator.animate_progress(ids.progress, 0.0, 1.0, 950, Easing::InOutSine);
+        }
+        // Stage 3: selector choreography + staggered sweeps.
+        _ => {
+            let _ = animator.animate_tab_selected(ids.tabs, 0, 3, 1100, Easing::InOutSine);
+            let _ = animator.animate_dropdown_selected(ids.dropdown, 0, 7, 1100, Easing::InOutSine);
+            let _ = animator.animate_roller_selected(ids.roller, 0, 7, 1100, Easing::OutCubic);
+            let _ = animator.stagger_widget_x(
+                &[ids.tabs, ids.dropdown],
+                164,
+                170,
+                850,
+                120,
+                Easing::OutSine,
+            );
+            let _ = animator.animate_widget_path(
+                ids.sweep_panel,
+                &[
+                    PathPoint::new(112.0, 24.0),
+                    PathPoint::new(120.0, 30.0),
+                    PathPoint::new(130.0, 24.0),
+                    PathPoint::new(122.0, 20.0),
+                    PathPoint::new(112.0, 24.0),
+                ],
+                1150,
+                Easing::InOutSine,
+            );
+        }
+    }
+}

--- a/examples/complex_layout_showcase.rs
+++ b/examples/complex_layout_showcase.rs
@@ -1,0 +1,149 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 240;
+const H: u32 = 140;
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("complex layout showcase", &settings);
+    let mut gui = GuiContext::<32, 64, 32>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+
+    relayout(&mut gui, &ids, false);
+    let mut use_flex = false;
+
+    'running: loop {
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Space => {
+                        use_flex = !use_flex;
+                        relayout(&mut gui, &ids, use_flex);
+                        let _ = gui.set_value_label(ids.mode, if use_flex { 1 } else { 0 });
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    stat_a: WidgetId,
+    stat_b: WidgetId,
+    stat_c: WidgetId,
+    panel_a: WidgetId,
+    panel_b: WidgetId,
+    panel_c: WidgetId,
+    mode: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 32, 64, 32>) -> Ids {
+    let root = gui
+        .add_panel(Rect::new(6, 6, 228, 128), Style::panel())
+        .unwrap();
+    gui.add_label(
+        Rect::new(10, 10, 220, 18),
+        "SPACE toggles between intrinsic and flex layout",
+        Style::label(),
+    )
+    .unwrap();
+    let mode = gui
+        .add_value_label(Rect::new(10, 28, 80, 12), "MODE", 0, Style::panel())
+        .unwrap();
+
+    let sidebar = gui
+        .add_panel(Rect::new(10, 44, 64, 80), Style::panel())
+        .unwrap();
+    let content = gui
+        .add_panel(Rect::new(78, 44, 154, 80), Style::panel())
+        .unwrap();
+    gui.add_child(root, sidebar).unwrap();
+    gui.add_child(root, content).unwrap();
+
+    let stat_a = gui
+        .add_value_label(Rect::new(0, 0, 1, 1), "CPU", 42, Style::panel())
+        .unwrap();
+    let stat_b = gui
+        .add_value_label(Rect::new(0, 0, 1, 1), "RAM", 68, Style::panel())
+        .unwrap();
+    let stat_c = gui
+        .add_value_label(Rect::new(0, 0, 1, 1), "NET", 17, Style::panel())
+        .unwrap();
+    gui.add_child(sidebar, stat_a).unwrap();
+    gui.add_child(sidebar, stat_b).unwrap();
+    gui.add_child(sidebar, stat_c).unwrap();
+
+    let panel_a = gui
+        .add_button(Rect::new(0, 0, 1, 1), "CHART", Style::button())
+        .unwrap();
+    let panel_b = gui
+        .add_button(Rect::new(0, 0, 1, 1), "DETAILS", Style::button())
+        .unwrap();
+    let panel_c = gui
+        .add_button(Rect::new(0, 0, 1, 1), "ACTIONS", Style::button())
+        .unwrap();
+    gui.add_child(content, panel_a).unwrap();
+    gui.add_child(content, panel_b).unwrap();
+    gui.add_child(content, panel_c).unwrap();
+
+    Ids {
+        stat_a,
+        stat_b,
+        stat_c,
+        panel_a,
+        panel_b,
+        panel_c,
+        mode,
+    }
+}
+
+fn relayout(gui: &mut GuiContext<'static, 32, 64, 32>, ids: &Ids, use_flex: bool) {
+    let _ = gui.apply_layout(
+        LinearLayout::column().with_gap(2).with_padding(EdgeInsets::all(2)),
+        Rect::new(0, 0, 64, 80),
+        &[ids.stat_a, ids.stat_b, ids.stat_c],
+    );
+
+    if use_flex {
+        let items = [
+            LayoutItem::length(18).with_grow(0),
+            LayoutItem::fill_weight(2),
+            LayoutItem::fill_weight(1),
+        ];
+        let _ = gui.apply_layout_flex(
+            LinearLayout::column().with_gap(2).with_padding(EdgeInsets::all(2)),
+            Rect::new(0, 0, 154, 80),
+            &[ids.panel_a, ids.panel_b, ids.panel_c],
+            &items,
+            true,
+            true,
+        );
+    } else {
+        let _ = gui.apply_layout_intrinsic_with_cross(
+            LinearLayout::column().with_gap(2).with_padding(EdgeInsets::all(2)),
+            Rect::new(0, 0, 154, 80),
+            &[ids.panel_a, ids.panel_b, ids.panel_c],
+            true,
+        );
+    }
+    let _ = gui.set_value_label(ids.mode, if use_flex { 1 } else { 0 });
+}

--- a/examples/form_flow_showcase.rs
+++ b/examples/form_flow_showcase.rs
@@ -1,0 +1,109 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 240;
+const H: u32 = 136;
+static LEVELS: [&str; 3] = ["LOW", "MED", "HIGH"];
+static MODES: [&str; 3] = ["AUTO", "MANUAL", "SAFE"];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("form flow showcase", &settings);
+
+    let mut gui = GuiContext::<32, 96, 32>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+    gui.set_state_transition_duration_ms(80);
+
+    'running: loop {
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Up => gui.handle_input(InputEvent::Up).unwrap(),
+                    Keycode::Down => gui.handle_input(InputEvent::Down).unwrap(),
+                    Keycode::Left => gui.handle_input(InputEvent::Left).unwrap(),
+                    Keycode::Right => gui.handle_input(InputEvent::Right).unwrap(),
+                    Keycode::Return => gui.handle_input(InputEvent::Select).unwrap(),
+                    Keycode::Backspace => gui.handle_input(InputEvent::Back).unwrap(),
+                    Keycode::Num1 => gui.textarea_insert_char(ids.note, '1').unwrap(),
+                    Keycode::Num2 => gui.textarea_insert_char(ids.note, '2').unwrap(),
+                    Keycode::Num3 => gui.textarea_insert_char(ids.note, '3').unwrap(),
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        gui.tick_input(16).unwrap();
+        while let Some(event) = gui.pop_event() {
+            if let UiEvent::Activate(id) = event {
+                if id == ids.apply {
+                    let summary = if gui.checked_value(ids.enable).unwrap_or(false) {
+                        "ENABLED"
+                    } else {
+                        "DISABLED"
+                    };
+                    let _ = gui.set_textarea_text(ids.status, summary);
+                }
+            }
+        }
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    enable: WidgetId,
+    note: WidgetId,
+    apply: WidgetId,
+    status: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 32, 96, 32>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 228, 124), Style::panel()).unwrap();
+    gui.add_label(
+        Rect::new(10, 10, 220, 18),
+        "UP/DOWN focus  LEFT/RIGHT value  ENTER select\nBACKSPACE closes dropdown  1/2/3 type",
+        Style::label(),
+    )
+    .unwrap();
+
+    let enable = gui
+        .add_checkbox(Rect::new(12, 38, 100, 16), "ENABLE", false, Style::button())
+        .unwrap();
+    let _mode = gui
+        .add_dropdown(Rect::new(116, 38, 108, 16), &MODES, 0, Style::button())
+        .unwrap();
+    let _level = gui
+        .add_roller(Rect::new(12, 58, 100, 28), &LEVELS, 1, Style::button())
+        .unwrap();
+    let note = gui
+        .add_textarea(Rect::new(116, 58, 108, 28), "N0TE", "NOTE", Style::panel())
+        .unwrap();
+    let apply = gui
+        .add_button(Rect::new(12, 92, 100, 16), "APPLY", Style::button())
+        .unwrap();
+    let status = gui
+        .add_textarea(Rect::new(116, 92, 108, 16), "IDLE", "-", Style::panel())
+        .unwrap();
+    gui.set_textarea_capabilities(status, true, true, false).unwrap();
+
+    Ids {
+        enable,
+        note,
+        apply,
+        status,
+    }
+}

--- a/examples/interaction_semantics_showcase.rs
+++ b/examples/interaction_semantics_showcase.rs
@@ -1,0 +1,140 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 220;
+const H: u32 = 128;
+static ITEMS: [&str; 4] = ["ALPHA", "BETA", "GAMMA", "DELTA"];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("interaction semantics showcase", &settings);
+
+    let mut gui = GuiContext::<24, 64, 24>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+    gui.set_state_transition_duration_ms(90);
+
+    let mut pointer_down = false;
+    let mut clicked = 0;
+    let mut closed = 0;
+    let mut released = 0;
+
+    'running: loop {
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Tab => {
+                        gui.handle_input(InputEvent::Down).unwrap();
+                    }
+                    Keycode::Return => {
+                        gui.handle_input(InputEvent::Select).unwrap();
+                    }
+                    Keycode::Backspace => {
+                        gui.handle_input(InputEvent::Back).unwrap();
+                    }
+                    // SPACE toggles a pointer hold over the top button.
+                    Keycode::Space => {
+                        pointer_down = !pointer_down;
+                        gui.handle_input(InputEvent::Pointer {
+                            x: 16,
+                            y: 58,
+                            state: if pointer_down {
+                                PointerState::Pressed
+                            } else {
+                                PointerState::Released
+                            },
+                            button: PointerButton::Primary,
+                        })
+                        .unwrap();
+                    }
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        gui.tick_input(16).unwrap();
+        while let Some(event) = gui.pop_event() {
+            match event {
+                UiEvent::Clicked(id) if id == ids.button => {
+                    clicked += 1;
+                    gui.set_value_label(ids.clicks, clicked).unwrap();
+                }
+                UiEvent::Closed(id) if id == ids.dropdown => {
+                    closed += 1;
+                    gui.set_value_label(ids.closed, closed).unwrap();
+                }
+                UiEvent::Released(id) if id == ids.button => {
+                    released += 1;
+                    gui.set_value_label(ids.released, released).unwrap();
+                }
+                _ => {}
+            }
+        }
+
+        gui.set_value_label(ids.transitions, gui.active_state_transitions() as i32)
+            .unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    button: WidgetId,
+    dropdown: WidgetId,
+    clicks: WidgetId,
+    closed: WidgetId,
+    released: WidgetId,
+    transitions: WidgetId,
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 24, 64, 24>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 208, 116), Style::panel()).unwrap();
+    gui.add_label(
+        Rect::new(10, 10, 200, 20),
+        "TAB focus  ENTER select  BACKSPACE closes dropdown\nSPACE pointer press/release",
+        Style::label(),
+    )
+    .unwrap();
+
+    let button = gui
+        .add_button(Rect::new(12, 50, 96, 18), "PRESS TARGET", Style::button())
+        .unwrap();
+    let dropdown = gui
+        .add_dropdown(Rect::new(112, 50, 96, 18), &ITEMS, 0, Style::button())
+        .unwrap();
+
+    let clicks = gui
+        .add_value_label(Rect::new(12, 76, 46, 12), "CLICK", 0, Style::panel())
+        .unwrap();
+    let closed = gui
+        .add_value_label(Rect::new(62, 76, 46, 12), "CLOSE", 0, Style::panel())
+        .unwrap();
+    let released = gui
+        .add_value_label(Rect::new(112, 76, 46, 12), "REL", 0, Style::panel())
+        .unwrap();
+    let transitions = gui
+        .add_value_label(Rect::new(162, 76, 46, 12), "TRANS", 0, Style::panel())
+        .unwrap();
+
+    Ids {
+        button,
+        dropdown,
+        clicks,
+        closed,
+        released,
+        transitions,
+    }
+}

--- a/examples/raw_key_input_showcase.rs
+++ b/examples/raw_key_input_showcase.rs
@@ -1,0 +1,183 @@
+use embedded_graphics_core::{
+    geometry::Size,
+    pixelcolor::{Rgb565, RgbColor},
+    prelude::DrawTarget,
+};
+use embedded_graphics_simulator::{
+    OutputSettingsBuilder, SimulatorDisplay, SimulatorEvent, Window, sdl2::Keycode,
+};
+use embedded_gui::prelude::*;
+
+const W: u32 = 220;
+const H: u32 = 128;
+static ITEMS: [&str; 3] = ["ONE", "TWO", "THREE"];
+
+fn main() {
+    let mut display = SimulatorDisplay::<Rgb565>::new(Size::new(W, H));
+    let settings = OutputSettingsBuilder::new().scale(4).build();
+    let mut window = Window::new("raw key input showcase", &settings);
+
+    let mut gui = GuiContext::<24, 64, 24>::new(Rect::new(0, 0, W, H));
+    let ids = build_ui(&mut gui);
+    gui.set_widget_key_input_policy(
+        ids.button,
+        WidgetKeyInputPolicy {
+            raw_select: true,
+            raw_back: false,
+        },
+    )
+    .unwrap();
+    gui.set_widget_key_input_policy(
+        ids.dropdown,
+        WidgetKeyInputPolicy {
+            raw_select: false,
+            raw_back: true,
+        },
+    )
+    .unwrap();
+    gui.set_focus(Some(ids.button)).unwrap();
+
+    'running: loop {
+        display.clear(Rgb565::BLACK).unwrap();
+        gui.render(&mut display).unwrap();
+        window.update(&display);
+
+        for event in window.events() {
+            match event {
+                SimulatorEvent::Quit => break 'running,
+                SimulatorEvent::KeyDown { keycode, .. } => match keycode {
+                    Keycode::Escape => break 'running,
+                    Keycode::Tab => gui.handle_input(InputEvent::Down).unwrap(),
+                    Keycode::S => gui.handle_input(InputEvent::SelectPressed).unwrap(),
+                    Keycode::Return => gui.handle_input(InputEvent::SelectReleased).unwrap(),
+                    Keycode::B => gui.handle_input(InputEvent::BackPressed).unwrap(),
+                    Keycode::Backspace => gui.handle_input(InputEvent::BackReleased).unwrap(),
+                    _ => {}
+                },
+                _ => {}
+            }
+        }
+
+        gui.tick_input(16).unwrap();
+        while let Some(event) = gui.pop_event() {
+            match event {
+                UiEvent::Pressed(id) if id == ids.button || id == ids.dropdown => {
+                    gui.set_value_label(ids.pressed_count, gui.value_of(ids.pressed_count) + 1)
+                        .unwrap();
+                }
+                UiEvent::Released(id) if id == ids.button || id == ids.dropdown => {
+                    gui.set_value_label(ids.released_count, gui.value_of(ids.released_count) + 1)
+                        .unwrap();
+                }
+                UiEvent::Clicked(id) if id == ids.button => {
+                    gui.set_value_label(ids.clicked_count, gui.value_of(ids.clicked_count) + 1)
+                        .unwrap();
+                }
+                UiEvent::Back => {
+                    gui.set_value_label(ids.back_count, gui.value_of(ids.back_count) + 1)
+                        .unwrap();
+                }
+                UiEvent::Closed(id) if id == ids.dropdown => {
+                    gui.set_value_label(ids.closed_count, gui.value_of(ids.closed_count) + 1)
+                        .unwrap();
+                }
+                _ => {}
+            }
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(16));
+    }
+}
+
+struct Ids {
+    button: WidgetId,
+    dropdown: WidgetId,
+    pressed_count: WidgetId,
+    released_count: WidgetId,
+    clicked_count: WidgetId,
+    back_count: WidgetId,
+    closed_count: WidgetId,
+}
+
+impl Ids {
+    fn counters(&self) -> [WidgetId; 5] {
+        [
+            self.pressed_count,
+            self.released_count,
+            self.clicked_count,
+            self.back_count,
+            self.closed_count,
+        ]
+    }
+}
+
+trait CounterAccess {
+    fn value_of(&self, id: WidgetId) -> i32;
+}
+
+impl<'a, const NODES: usize, const EVENTS: usize, const DIRTY: usize> CounterAccess
+    for GuiContext<'a, NODES, EVENTS, DIRTY>
+{
+    fn value_of(&self, id: WidgetId) -> i32 {
+        self.widgets()
+            .iter()
+            .find(|w| w.id == id)
+            .and_then(|w| {
+                if let WidgetKind::ValueLabel { value, .. } = w.kind {
+                    Some(value)
+                } else {
+                    None
+                }
+            })
+            .unwrap_or(0)
+    }
+}
+
+fn build_ui(gui: &mut GuiContext<'static, 24, 64, 24>) -> Ids {
+    gui.add_panel(Rect::new(6, 6, 208, 116), Style::panel()).unwrap();
+    gui.add_label(
+        Rect::new(10, 10, 198, 24),
+        "TAB focus\nS=SelectPressed ENTER=SelectReleased\nB=BackPressed BACKSPACE=BackReleased",
+        Style::label(),
+    )
+    .unwrap();
+
+    let button = gui
+        .add_button(Rect::new(12, 42, 94, 16), "RAW SELECT", Style::button())
+        .unwrap();
+    let dropdown = gui
+        .add_dropdown(Rect::new(112, 42, 96, 16), &ITEMS, 0, Style::button())
+        .unwrap();
+    gui.set_dropdown_open(dropdown, true).unwrap();
+
+    let pressed_count = gui
+        .add_value_label(Rect::new(12, 64, 62, 12), "PRESS", 0, Style::panel())
+        .unwrap();
+    let released_count = gui
+        .add_value_label(Rect::new(78, 64, 62, 12), "RELEASE", 0, Style::panel())
+        .unwrap();
+    let clicked_count = gui
+        .add_value_label(Rect::new(144, 64, 62, 12), "CLICK", 0, Style::panel())
+        .unwrap();
+    let back_count = gui
+        .add_value_label(Rect::new(12, 80, 94, 12), "BACK", 0, Style::panel())
+        .unwrap();
+    let closed_count = gui
+        .add_value_label(Rect::new(112, 80, 96, 12), "CLOSED", 0, Style::panel())
+        .unwrap();
+
+    let ids = Ids {
+        button,
+        dropdown,
+        pressed_count,
+        released_count,
+        clicked_count,
+        back_count,
+        closed_count,
+    };
+
+    for id in ids.counters() {
+        gui.set_value_label(id, 0).unwrap();
+    }
+    ids
+}


### PR DESCRIPTION
## Summary
- add interaction semantics and raw key input showcase examples for simulator workflows
- add form-flow and complex-layout showcases to exercise multi-widget behavior and composition
- include animation motion showcase for quick visual validation of movement primitives

## Test plan
- [x] `cargo check --examples`